### PR TITLE
XML形式のサイトマップを作成するエンドポイントを追加

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Sitemap: https://lgtmeow.com/sitemap.xml

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -1,0 +1,25 @@
+import { GetServerSidePropsContext } from 'next';
+import generateSitemapXml from '../utils/generateSitemapXml';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const getServerSideProps = async ({
+  res,
+}: // eslint-disable-next-line @typescript-eslint/require-await
+GetServerSidePropsContext) => {
+  const xml = generateSitemapXml();
+
+  res.statusCode = 200;
+  // 24時間キャッシュさせる、もっと長くても良いかも
+  res.setHeader('Cache-Control', 's-maxage=86400, stale-while-revalidate');
+  res.setHeader('Content-Type', 'text/xml');
+  res.end(xml);
+
+  return {
+    props: {},
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const SitemapPage = () => null;
+
+export default SitemapPage;

--- a/src/utils/__test__/generateSitemapXml.spec.ts
+++ b/src/utils/__test__/generateSitemapXml.spec.ts
@@ -10,11 +10,11 @@ describe('generateSitemapXml.ts Functions TestCases', () => {
     </url>
     <url>
       <loc>https://lgtmeow.com/terms/</loc>
-      <changefreq>weekly</changefreq>
+      <changefreq>monthly</changefreq>
     </url>
     <url>
       <loc>https://lgtmeow.com/privacy/</loc>
-      <changefreq>weekly</changefreq>
+      <changefreq>monthly</changefreq>
     </url>
   </urlset>`;
 

--- a/src/utils/__test__/generateSitemapXml.spec.ts
+++ b/src/utils/__test__/generateSitemapXml.spec.ts
@@ -1,0 +1,23 @@
+import generateSitemapXml from '../generateSitemapXml';
+
+describe('generateSitemapXml.ts Functions TestCases', () => {
+  it('should return the sitemap.xml', () => {
+    const result = generateSitemapXml();
+    const expected = `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+      <loc>https://lgtmeow.com/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
+      <loc>https://lgtmeow.com/terms/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
+      <loc>https://lgtmeow.com/privacy/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+  </urlset>`;
+
+    expect(result).toStrictEqual(expected);
+  });
+});

--- a/src/utils/generateSitemapXml.ts
+++ b/src/utils/generateSitemapXml.ts
@@ -2,23 +2,20 @@ const generateSitemapXml = (): string => {
   let xml = `<?xml version="1.0" encoding="UTF-8"?>`;
   xml += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 
-  const targetUrlList = [
-    'https://lgtmeow.com/',
-    'https://lgtmeow.com/terms/',
-    'https://lgtmeow.com/privacy/',
-  ];
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const targetUrl of targetUrlList) {
-    xml += `
-      <url>
-        <loc>${targetUrl}</loc>
-        <changefreq>weekly</changefreq>
-      </url>
-    `;
-  }
-
-  xml += `</urlset>`;
+  xml += `
+    <url>
+      <loc>https://lgtmeow.com/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
+      <loc>https://lgtmeow.com/terms/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
+      <loc>https://lgtmeow.com/privacy/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+  </urlset>`;
 
   return xml;
 };

--- a/src/utils/generateSitemapXml.ts
+++ b/src/utils/generateSitemapXml.ts
@@ -1,0 +1,26 @@
+const generateSitemapXml = (): string => {
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>`;
+  xml += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
+
+  const targetUrlList = [
+    'https://lgtmeow.com/',
+    'https://lgtmeow.com/terms/',
+    'https://lgtmeow.com/privacy/',
+  ];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const targetUrl of targetUrlList) {
+    xml += `
+      <url>
+        <loc>${targetUrl}</loc>
+        <changefreq>weekly</changefreq>
+      </url>
+    `;
+  }
+
+  xml += `</urlset>`;
+
+  return xml;
+};
+
+export default generateSitemapXml;

--- a/src/utils/generateSitemapXml.ts
+++ b/src/utils/generateSitemapXml.ts
@@ -9,11 +9,11 @@ const generateSitemapXml = (): string => {
     </url>
     <url>
       <loc>https://lgtmeow.com/terms/</loc>
-      <changefreq>weekly</changefreq>
+      <changefreq>monthly</changefreq>
     </url>
     <url>
       <loc>https://lgtmeow.com/privacy/</loc>
-      <changefreq>weekly</changefreq>
+      <changefreq>monthly</changefreq>
     </url>
   </urlset>`;
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/21

# 関連URL
http://localhost:3000/sitemap.xml
http://localhost:3000/robots.txt

# Doneの定義
- サイトマップを表示させるエンドポイントが実装されている事

# スクリーンショット
以下のようなサイトマップが表示される。

![sitemap](https://user-images.githubusercontent.com/11032365/109446864-d227e100-7a85-11eb-9cda-e7ff51c30ddb.png)

# 変更点概要

`/sitemap.xml` でXML形式のサイトマップを生成する処理を追加。

[こちらの記事](https://zenn.dev/catnose99/articles/c441954a987c24) を参考にさせてもらった。

サイトマップ内のURLは本番環境固定、lastmodに関しては、更新日時を動的に取得するのが難しいと判断した為、追加は行っていない。（例えばランダムで表示されている画像が変わっただけでも更新と見なされるのか？が分からなかった・・・）

`priority` は設定の仕方がよく分からず、以下の記事を始めとする記事にも重要ではないと書かれていたので、省略した。

https://www.suzukikenichi.com/blog/google-ignores-priority-but-uses-lastmod-in-sitemaps/

なお `robots.txt` も追加してある。

# レビュアーに重点的にチェックして欲しい点

とりあえず `/sitemap.xml` に記載されているURLとパスが合っているか見てもらえると:pray:

↓ここから下は半分独り言、今後対応方針決めて対応するのはアリかも↓

やった後で気がついたけど、 `lastmod` を使わないならもう `/public` に普通に `sitemap.xml` を置くだけでもアリかもと気がついた・・・:cat2:

まあ動的生成出来る機能が出来たという事で・・・

あと、https://github.com/nekochans/lgtm-cat-frontend/issues/12 で `getStaticProps` を使うようになるから、そのタイミングで `lastmod` を更新した `/sitemap.xml` を `/public` に置くのもアリかも？？