### PR TITLE
GitHubマークダウン用ソースをコピー出来る機能を作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "bulma": "^0.9.2",
+    "clipboard": "^2.0.6",
     "next": "^10.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -37,6 +38,7 @@
     "@storybook/addon-storyshots": "^6.1.18",
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.1.18",
+    "@types/clipboard": "^2.0.1",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.28",
     "@types/prettier": "^2.2.1",

--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Props 1`] = `
+<div
+  className="column is-one-third"
+  onClick={[Function]}
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "margin": "auto",
+        "position": "relative",
+        "textAlign": "center",
+      }
+    }
+  >
+    <img
+      alt="lgtm cat"
+      src="/cat.jpeg"
+      style={
+        Object {
+          "maxHeight": "300px",
+          "padding": "0.75rem",
+        }
+      }
+    />
+  </div>
+</div>
+`;

--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -3,7 +3,6 @@
 exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Props 1`] = `
 <div
   className="column is-one-third"
-  onClick={[Function]}
 >
   <div
     style={

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -10,12 +10,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -34,12 +36,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -58,12 +62,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -86,12 +92,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -110,12 +118,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -134,12 +144,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -162,12 +174,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -186,12 +200,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }
@@ -210,12 +226,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
+        onClick={[Function]}
       >
         <div
           style={
             Object {
               "height": "100%",
               "margin": "auto",
+              "position": "relative",
               "textAlign": "center",
             }
           }

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -10,7 +10,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -36,7 +35,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -62,7 +60,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -92,7 +89,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -118,7 +114,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -144,7 +139,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -174,7 +168,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
     >
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -200,7 +193,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={
@@ -226,7 +218,6 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
       </div>
       <div
         className="column is-one-third"
-        onClick={[Function]}
       >
         <div
           style={

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -6,7 +6,6 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
 >
   <div
     className="column is-one-third"
-    onClick={[Function]}
   >
     <div
       style={
@@ -32,7 +31,6 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
   </div>
   <div
     className="column is-one-third"
-    onClick={[Function]}
   >
     <div
       style={
@@ -58,7 +56,6 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
   </div>
   <div
     className="column is-one-third"
-    onClick={[Function]}
   >
     <div
       style={

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -6,12 +6,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
 >
   <div
     className="column is-one-third"
+    onClick={[Function]}
   >
     <div
       style={
         Object {
           "height": "100%",
           "margin": "auto",
+          "position": "relative",
           "textAlign": "center",
         }
       }
@@ -30,12 +32,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
   </div>
   <div
     className="column is-one-third"
+    onClick={[Function]}
   >
     <div
       style={
         Object {
           "height": "100%",
           "margin": "auto",
+          "position": "relative",
           "textAlign": "center",
         }
       }
@@ -54,12 +58,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
   </div>
   <div
     className="column is-one-third"
+    onClick={[Function]}
   >
     <div
       style={
         Object {
           "height": "100%",
           "margin": "auto",
+          "position": "relative",
           "textAlign": "center",
         }
       }

--- a/src/__tests__/storybook.test.ts
+++ b/src/__tests__/storybook.test.ts
@@ -2,4 +2,6 @@ import initStoryshots, {
   multiSnapshotWithOptions,
 } from '@storybook/addon-storyshots';
 
+jest.mock('../hooks/useClipboardMarkdown', () => () => '');
+
 initStoryshots({ test: multiSnapshotWithOptions() });

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Image } from '../domain/image';
+
+type Props = {
+  image: Image;
+};
+
+const ImageContent: React.FC<Props> = ({ image }: Props) => {
+  const [copied, setCopied] = useState(false);
+  const onClicked = () => {
+    setCopied(true);
+  };
+
+  return (
+    // eslint-disable-next-line
+    <div
+      className="column is-one-third"
+      key={image.id}
+      onClick={() => onClicked()}
+    >
+      <div
+        style={{
+          margin: 'auto',
+          height: '100%',
+          textAlign: 'center',
+          position: 'relative',
+        }}
+      >
+        <img
+          src={image.url}
+          style={{ maxHeight: '300px', padding: '0.75rem' }}
+          alt="lgtm cat"
+        />
+        {copied && (
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '10%',
+              left: '50%',
+              color: 'white',
+              transform: 'translate(-50%, 0)',
+              background: 'rgba(0, 0, 0, 0.5)',
+              borderRadius: '30px',
+              padding: '3%',
+            }}
+          >
+            Github Markdown Copied!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+export default ImageContent;

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Image } from '../domain/image';
+import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
 
 type Props = {
   image: Image;
@@ -7,17 +8,18 @@ type Props = {
 
 const ImageContent: React.FC<Props> = ({ image }: Props) => {
   const [copied, setCopied] = useState(false);
-  const onClicked = () => {
+
+  const onCopySuccess = useCallback(() => {
     setCopied(true);
-  };
+    setTimeout(() => {
+      setCopied(false);
+    }, 1000);
+  }, []);
+
+  const { imageContextRef } = useClipboardMarkdown(onCopySuccess, image.url);
 
   return (
-    // eslint-disable-next-line
-    <div
-      className="column is-one-third"
-      key={image.id}
-      onClick={() => onClicked()}
-    >
+    <div className="column is-one-third" key={image.id} ref={imageContextRef}>
       <div
         style={{
           margin: 'auto',

--- a/src/components/ImageContext.stories.tsx
+++ b/src/components/ImageContext.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ImageContext from './ImageContent';
+
+export default {
+  title: 'src/components/ImageContext.tsx',
+  component: ImageContext,
+  includeStories: ['showImageContextWithProps'],
+};
+
+export const testProps = {
+  imageList: {
+    id: 1,
+    url: '/cat.jpeg',
+  },
+};
+
+export const showImageContextWithProps = (): JSX.Element => (
+  <ImageContext image={testProps.imageList} />
+);

--- a/src/components/ImageRow.tsx
+++ b/src/components/ImageRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image } from '../domain/image';
+import ImageContent from './ImageContent';
 
 type Props = {
   imageList: Image[];
@@ -8,21 +9,7 @@ type Props = {
 const ImageRow: React.FC<Props> = ({ imageList }: Props) => (
   <div className="columns">
     {imageList.map((image) => (
-      <div className="column is-one-third" key={image.id}>
-        <div
-          style={{
-            margin: 'auto',
-            height: '100%',
-            textAlign: 'center',
-          }}
-        >
-          <img
-            src={image.url}
-            style={{ maxHeight: '300px', padding: '0.75rem' }}
-            alt="lgtm cat"
-          />
-        </div>
-      </div>
+      <ImageContent image={image} key={image.id} />
     ))}
   </div>
 );

--- a/src/hooks/useClipboardMarkdown.ts
+++ b/src/hooks/useClipboardMarkdown.ts
@@ -1,0 +1,26 @@
+import { MutableRefObject, useEffect, useRef } from 'react';
+import Clipboard from 'clipboard';
+
+const useClipboardMarkdown = (
+  onCopySuccess: () => void,
+  url: string,
+): { imageContextRef: MutableRefObject<null> } => {
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    const cb = new Clipboard(buttonRef.current!, {
+      text: () => `![LGTMeow](${url})`,
+    });
+    cb.on('success', () => {
+      onCopySuccess();
+    });
+
+    return () => {
+      cb.destroy();
+    };
+  }, [onCopySuccess, url]);
+
+  return { imageContextRef: buttonRef };
+};
+
+export default useClipboardMarkdown;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,6 +2305,11 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
+"@types/clipboard@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
+  integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -4441,7 +4446,7 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
-clipboard@^2.0.0:
+clipboard@^2.0.0, clipboard@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
   integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/13

# 関連URL
[optional]

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/13 の完了の定義が満たされていること

# スクリーンショット
画像をクリックした時のイメージ (メッセージは1秒後に消える)

<img width="1401" alt="スクリーンショット 2021-03-05 22 48 20" src="https://user-images.githubusercontent.com/32682645/110125149-58398400-7e06-11eb-9615-e7c40af2ddca.png">
<img width="397" alt="スクリーンショット 2021-03-05 22 48 44" src="https://user-images.githubusercontent.com/32682645/110125162-5bcd0b00-7e06-11eb-937c-683c40805536.png">

# 変更点概要
LGTM画像をクリックした際に「Github Markdown Copied!」のメッセージをLGTM画像の上に表示する処理を追加
LGTM画像をクリックした際に、Markdownをクリップボードにコピーする処理を追加

# 補足情報
クリップボードへのコピーは下記のブログを参考にしている。
https://blog.terrier.dev/blog/2019/20190223000000-clipboard-js-react-hooks/

Custom Hookのテストは時間がかかりそうだったので、別の課題として対応予定。