### PR TITLE
トップページの上部に簡単な使い方を追記する

### DIFF
--- a/src/__tests__/__snapshots__/Footer.stories.storyshot
+++ b/src/__tests__/__snapshots__/Footer.stories.storyshot
@@ -5,45 +5,53 @@ exports[`Storyshots src/components/Footer.tsx Show Footer With Props 1`] = `
   className="footer"
 >
   <div
-    className="level-left"
+    className="container"
   >
     <div
-      className="level-item breadcrumb"
+      className="level-left"
     >
-      <ul>
-        <li>
-          <a
-            href="https://policies.google.com/terms"
-            style={
-              Object {
-                "color": "royalblue",
+      <div
+        className="level-item breadcrumb"
+      >
+        <ul>
+          <li>
+            <a
+              href="https://policies.google.com/terms"
+              style={
+                Object {
+                  "color": "royalblue",
+                }
               }
-            }
-          >
-            利用規約
-          </a>
-        </li>
-        <li>
-          <a
-            href="https://policies.google.com/privacy"
-            style={
-              Object {
-                "color": "royalblue",
+            >
+              利用規約
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://policies.google.com/privacy"
+              style={
+                Object {
+                  "color": "royalblue",
+                }
               }
-            }
-          >
-            プライバシーポリシー
-          </a>
-        </li>
-      </ul>
+            >
+              プライバシーポリシー
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-  <div
-    className="content has-text-centered"
-  >
-    <p>
-      Copyright (c) nekochans
-    </p>
+    <div
+      className="level-right"
+    >
+      <div
+        className="content has-text-centered"
+      >
+        <p>
+          Copyright (c) nekochans
+        </p>
+      </div>
+    </div>
   </div>
 </footer>
 `;

--- a/src/__tests__/__snapshots__/Header.stories.storyshot
+++ b/src/__tests__/__snapshots__/Header.stories.storyshot
@@ -48,6 +48,17 @@ exports[`Storyshots src/components/Header.tsx Show Header 1`] = `
           </button>
         </div>
       </div>
+      <p
+        className="is-size-6 header-description-margin has-text-grey"
+        style={
+          Object {
+            "alignItems": "center",
+            "padding": "0 0.75rem",
+          }
+        }
+      >
+        猫のLGTM画像を共有出来るサービスです。画像をクリックするとGitHub Markdownがコピーされます。
+      </p>
     </div>
   </nav>
 </header>

--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -19,6 +19,7 @@ exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Prop
       src="/cat.jpeg"
       style={
         Object {
+          "cursor": "pointer",
           "maxHeight": "300px",
           "padding": "0.75rem",
         }

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -26,6 +26,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -51,6 +52,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat2.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -76,6 +78,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -105,6 +108,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat2.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -130,6 +134,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -155,6 +160,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat2.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -184,6 +190,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -209,6 +216,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat2.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }
@@ -234,6 +242,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             src="/cat.jpeg"
             style={
               Object {
+                "cursor": "pointer",
                 "maxHeight": "300px",
                 "padding": "0.75rem",
               }

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -22,6 +22,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         src="/cat.jpeg"
         style={
           Object {
+            "cursor": "pointer",
             "maxHeight": "300px",
             "padding": "0.75rem",
           }
@@ -47,6 +48,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         src="/cat2.jpeg"
         style={
           Object {
+            "cursor": "pointer",
             "maxHeight": "300px",
             "padding": "0.75rem",
           }
@@ -72,6 +74,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         src="/cat.jpeg"
         style={
           Object {
+            "cursor": "pointer",
             "maxHeight": "300px",
             "padding": "0.75rem",
           }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,16 +7,20 @@ type Props = {
 
 const Footer: React.FC<Props> = ({ termsLink, privacyLink }: Props) => (
   <footer className="footer">
-    <div className="level-left">
-      <div className="level-item breadcrumb">
-        <ul>
-          <li>{termsLink}</li>
-          <li>{privacyLink}</li>
-        </ul>
+    <div className="container">
+      <div className="level-left">
+        <div className="level-item breadcrumb">
+          <ul>
+            <li>{termsLink}</li>
+            <li>{privacyLink}</li>
+          </ul>
+        </div>
       </div>
-    </div>
-    <div className="content has-text-centered">
-      <p>Copyright (c) nekochans</p>
+      <div className="level-right">
+        <div className="content has-text-centered">
+          <p>Copyright (c) nekochans</p>
+        </div>
+      </div>
     </div>
   </footer>
 );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,6 +25,16 @@ const Header: React.FC = () => (
             </button>
           </div>
         </div>
+        <p
+          className="is-size-6 header-description-margin has-text-grey"
+          style={{
+            alignItems: 'center',
+            padding: '0 0.75rem',
+          }}
+        >
+          猫のLGTM画像を共有出来るサービスです。画像をクリックするとGitHub
+          Markdownがコピーされます。
+        </p>
       </div>
     </nav>
   </header>

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -30,7 +30,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
       >
         <img
           src={image.url}
-          style={{ maxHeight: '300px', padding: '0.75rem' }}
+          style={{ maxHeight: '300px', padding: '0.75rem', cursor: 'pointer' }}
           alt="lgtm cat"
         />
         {copied && (

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -8,6 +8,12 @@
 
 @media screen and (min-width: 1216px) {
   .navbar-padding {
-    padding: 2rem 4rem;
+    padding: 1rem 4rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .header-description-margin {
+    margin-left: -0.75rem;
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/29

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/29 の完了の定義が満たされていること

# スクリーンショット
- Header
<img width="1350" alt="スクリーンショット 2021-03-09 0 59 26" src="https://user-images.githubusercontent.com/32682645/110346278-bc608000-8072-11eb-8611-1c877fc719e9.png">
<img width="322" alt="スクリーンショット 2021-03-09 1 00 14" src="https://user-images.githubusercontent.com/32682645/110346381-d4380400-8072-11eb-80ff-793bce1e0cf9.png">

- Footer
<img width="1358" alt="スクリーンショット 2021-03-09 1 17 56" src="https://user-images.githubusercontent.com/32682645/110348820-66d9a280-8075-11eb-8033-cd09f5bfea3a.png">
<img width="384" alt="スクリーンショット 2021-03-09 1 18 12" src="https://user-images.githubusercontent.com/32682645/110348859-70fba100-8075-11eb-8f3e-4dd644283096.png">

# 変更点概要
- トップページのHeaderにサービスの説明を追加

Issueとは関係ないが下記のスタイルも変更した
- 画像にマウスオーバーした際のカーソルをpointerに変更
- Footerのスタイルを修正
  - コピーライトを右寄せに変更
  - marginがHeaderとずれていたので、Headerに揃えるように修正