### PR TITLE
htmlタグのprefix属性にOGP画像の利用を宣言する内容を追加

### DIFF
--- a/src/hooks/useClipboardMarkdown.ts
+++ b/src/hooks/useClipboardMarkdown.ts
@@ -8,6 +8,7 @@ const useClipboardMarkdown = (
   const buttonRef = useRef(null);
 
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const cb = new Clipboard(buttonRef.current!, {
       text: () => `![LGTMeow](${url})`,
     });

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -22,7 +22,7 @@ export default class CustomDocument extends Document {
 
   render(): JSX.Element {
     return (
-      <Html>
+      <Html prefix="og: https://ogp.me/ns#">
         <Head>
           {/* Google Analytics */}
           <script


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/36

# Doneの定義
- https://github.com/nekochans/lgtm-cat-frontend/issues/36 の完了の定義を満たしている事

# スクリーンショット
[optional] ただしUI変更の時は [required]

# 変更点概要

以下の公式ドキュメントに従いHTMLタグに `prefix="og: https://ogp.me/ns#"` を追加。

https://ogp.me/

それからPRの目的とは、直接関係はないが `warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion` が出ていた箇所を処理の内容的に問題ないと判断し `eslint-disable-next-line` で無効化した。

# 補足情報

実装の際には以下の記事を参考にしたが、404ページだけ `prefix` を表示させない等の対応を行うと型定義の解決が難しそう + やる意味がどの程度あるのか不明だったので、今回は単純に `prefix="og: https://ogp.me/ns#"` を追加するだけにしてある。

https://panda-program.com/posts/nextjs-html-prefix