### PR TITLE
画像を選択しやすくするために画像をマウスオーバーした際のスタイルを追加

### DIFF
--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -16,11 +16,14 @@ exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Prop
   >
     <img
       alt="lgtm cat"
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
       src="/cat.jpeg"
       style={
         Object {
           "cursor": "pointer",
           "maxHeight": "300px",
+          "opacity": "1",
           "padding": "0.75rem",
         }
       }

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -23,11 +23,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -49,11 +52,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat2.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -75,11 +81,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -105,11 +114,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat2.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -131,11 +143,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -157,11 +172,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat2.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -187,11 +205,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -213,11 +234,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat2.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }
@@ -239,11 +263,14 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         >
           <img
             alt="lgtm cat"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
             src="/cat.jpeg"
             style={
               Object {
                 "cursor": "pointer",
                 "maxHeight": "300px",
+                "opacity": "1",
                 "padding": "0.75rem",
               }
             }

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -19,11 +19,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
     >
       <img
         alt="lgtm cat"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         src="/cat.jpeg"
         style={
           Object {
             "cursor": "pointer",
             "maxHeight": "300px",
+            "opacity": "1",
             "padding": "0.75rem",
           }
         }
@@ -45,11 +48,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
     >
       <img
         alt="lgtm cat"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         src="/cat2.jpeg"
         style={
           Object {
             "cursor": "pointer",
             "maxHeight": "300px",
+            "opacity": "1",
             "padding": "0.75rem",
           }
         }
@@ -71,11 +77,14 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
     >
       <img
         alt="lgtm cat"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
         src="/cat.jpeg"
         style={
           Object {
             "cursor": "pointer",
             "maxHeight": "300px",
+            "opacity": "1",
             "padding": "0.75rem",
           }
         }

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -8,6 +8,7 @@ type Props = {
 
 const ImageContent: React.FC<Props> = ({ image }: Props) => {
   const [copied, setCopied] = useState(false);
+  const [opacity, setOpacity] = useState('1');
 
   const onCopySuccess = useCallback(() => {
     setCopied(true);
@@ -17,6 +18,13 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
   }, []);
 
   const { imageContextRef } = useClipboardMarkdown(onCopySuccess, image.url);
+
+  const imageStyles = {
+    maxHeight: '300px',
+    padding: '0.75rem',
+    cursor: 'pointer',
+    opacity,
+  };
 
   return (
     <div className="column is-one-third" key={image.id} ref={imageContextRef}>
@@ -30,8 +38,10 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
       >
         <img
           src={image.url}
-          style={{ maxHeight: '300px', padding: '0.75rem', cursor: 'pointer' }}
+          style={imageStyles}
           alt="lgtm cat"
+          onMouseEnter={() => setOpacity('0.7')}
+          onMouseLeave={() => setOpacity('1')}
         />
         {copied && (
           <div


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/42

# 関連URL
https://lgtm-cat-frontend-git-feature-issue42-nekochans.vercel.app/

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/42 の完了の定義が満たされていること

# スクリーンショット
- 何もしていないとき
<img width="431" alt="スクリーンショット 2021-03-17 23 59 58" src="https://user-images.githubusercontent.com/32682645/111493475-edcb0100-8780-11eb-9029-79222737e7a7.png">
- マウスオーバーしているとき
<img width="430" alt="スクリーンショット 2021-03-17 23 59 47" src="https://user-images.githubusercontent.com/32682645/111493489-f15e8800-8780-11eb-9a67-5a797dbde74f.png">

# 変更点概要
- 画像を選択しやすくするために、画像にマウスオーバーした際のスタイルを追加
