### PR TITLE
ヘッダーサービス名押下時のトップページへの遷移方法NextRouterを使用するように変更

### DIFF
--- a/src/__tests__/__snapshots__/Header.stories.storyshot
+++ b/src/__tests__/__snapshots__/Header.stories.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots src/components/Header.tsx Show Header 1`] = `
       >
         <a
           className="navbar-item"
-          href=""
+          href="https://policies.google.com"
         >
           <p
             className="is-size-4 has-text-black"

--- a/src/__tests__/__snapshots__/SimpleHeader.stories.storyshot
+++ b/src/__tests__/__snapshots__/SimpleHeader.stories.storyshot
@@ -18,7 +18,7 @@ exports[`Storyshots src/components/SimpleHeader.tsx Show Simple Header 1`] = `
       >
         <a
           className="navbar-item"
-          href=""
+          href="https://policies.google.com"
         >
           <p
             className="is-size-4 has-text-black"

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -7,4 +7,12 @@ export default {
   includeStories: ['showHeader'],
 };
 
-export const showHeader = (): JSX.Element => <Header />;
+const props = {
+  topLink: (
+    <a className="navbar-item" href="https://policies.google.com">
+      <p className="is-size-4 has-text-black">LGTMeow</p>
+    </a>
+  ),
+};
+
+export const showHeader = (): JSX.Element => <Header topLink={props.topLink} />;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import { urlList } from '../constants/url';
+import React, { ReactNode } from 'react';
 import RandomButtonContainer from '../containers/RandomButton';
 
-const Header: React.FC = () => (
+type Props = {
+  topLink: ReactNode;
+};
+
+const Header: React.FC<Props> = ({ topLink }: Props) => (
   <header>
     <nav className="navbar navbar-padding">
       <div className="container" style={{ display: 'block' }}>
         <div className="navbar-brand">
-          <a className="navbar-item" href={urlList.top}>
-            <p className="is-size-4 has-text-black">LGTMeow</p>
-          </a>
+          {topLink}
           <div
             style={{
               alignItems: 'center',

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,7 +24,16 @@ const Layout: React.FC<Props> = ({ children, metaTag }: Props) => (
       <meta property="og:url" content={metaTag.ogpTargetUrl} />
       <meta property="og:site_name" content={metaTag.title} />
     </Head>
-    <Header />
+    <Header
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a className="navbar-item">
+            <p className="is-size-4 has-text-black">LGTMeow</p>
+          </a>
+        </Link>
+      }
+    />
     {children}
     <Footer
       termsLink={

--- a/src/components/SimpleHeader.stories.tsx
+++ b/src/components/SimpleHeader.stories.tsx
@@ -7,4 +7,14 @@ export default {
   includeStories: ['showSimpleHeader'],
 };
 
-export const showSimpleHeader = (): JSX.Element => <SimpleHeader />;
+const props = {
+  topLink: (
+    <a className="navbar-item" href="https://policies.google.com">
+      <p className="is-size-4 has-text-black">LGTMeow</p>
+    </a>
+  ),
+};
+
+export const showSimpleHeader = (): JSX.Element => (
+  <SimpleHeader topLink={props.topLink} />
+);

--- a/src/components/SimpleHeader.tsx
+++ b/src/components/SimpleHeader.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { urlList } from '../constants/url';
+import React, { ReactNode } from 'react';
 
-const SimpleHeader: React.FC = () => (
+type Props = {
+  topLink: ReactNode;
+};
+const SimpleHeader: React.FC<Props> = ({ topLink }: Props) => (
   <header>
     <nav className="navbar navbar-padding">
       <div className="container" style={{ display: 'block' }}>
         <div className="navbar-brand">
-          <a className="navbar-item" href={urlList.top}>
-            <p className="is-size-4 has-text-black">LGTMeow</p>
-          </a>
+          {topLink}
           <div
             style={{
               alignItems: 'center',

--- a/src/components/SimpleLayout.tsx
+++ b/src/components/SimpleLayout.tsx
@@ -23,7 +23,16 @@ const SimpleLayout: React.FC<Props> = ({ children, metaTag }: Props) => (
       <meta property="og:url" content={metaTag.ogpTargetUrl} />
       <meta property="og:site_name" content={metaTag.title} />
     </Head>
-    <SimpleHeader />
+    <SimpleHeader
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a className="navbar-item">
+            <p className="is-size-4 has-text-black">LGTMeow</p>
+          </a>
+        </Link>
+      }
+    />
     {children}
     <Footer
       termsLink={


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/31

# 関連URL
[optional]

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/31 の完了条件が満たされていること

# 変更点概要
トップページへの遷移方法を aタグの href ではなく、NextRouter を使用するように変更。
修正対象のコンポーネントは下記の2つ。
- SimpleHeader
- Header