### PR TITLE
画像要素はNext.jsのImageコンポーネントを利用するように変更を行う

### DIFF
--- a/.storybook/__mocks/NextImage.tsx
+++ b/.storybook/__mocks/NextImage.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import * as nextImage from "next/image"
+
+// https://github.com/vercel/next.js/issues/18393#issuecomment-750910068 を参考にしている
+Object.defineProperty(nextImage, "default", {
+  configurable: true,
+  value: (props: any) => {
+    const height = props.height
+    const width = props.width
+    const quotient = height / width
+    const paddingTop = isNaN(quotient) ? "100%" : `${quotient * 100}%`
+    let wrapperStyle
+    let sizerStyle
+    let sizerSvg
+    let toBase64
+    let imgStyle = {
+      position: "absolute",
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      boxSizing: "border-box",
+      padding: 0,
+      border: "none",
+      margin: "auto",
+      display: "block",
+      width: 0,
+      height: 0,
+      minWidth: "100%",
+      maxWidth: "100%",
+      minHeight: "100%",
+      maxHeight: "100%",
+      objectFit: props.objectFit ? props.objectFit : undefined,
+      objectPosition: props.objectPosition ? props.objectPosition : undefined,
+    }
+
+    if (width !== undefined && height !== undefined && props.layout !== "fill") {
+      if (props.layout === "responsive") {
+        wrapperStyle = {
+          display: "block",
+          overflow: "hidden",
+          position: "relative",
+          boxSizing: "border-box",
+          margin: 0,
+        }
+        sizerStyle = {
+          display: "block",
+          boxSizing: "border-box",
+          paddingTop,
+        }
+      } else if (props.layout === "intrinsic" || props.layout === undefined) {
+        wrapperStyle = {
+          display: "inline-block",
+          maxWidth: "100%",
+          overflow: "hidden",
+          position: "relative",
+          boxSizing: "border-box",
+          margin: 0,
+        }
+        sizerStyle = {
+          boxSizing: "border-box",
+          display: "block",
+          maxWidth: "100%",
+        }
+        sizerSvg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg" version="1.1"/>`
+        toBase64 = Buffer.from(sizerSvg).toString("base64")
+      } else if (props.layout === "fixed") {
+        wrapperStyle = {
+          overflow: "hidden",
+          boxSizing: "border-box",
+          display: "inline-block",
+          position: "relative",
+          width,
+          height,
+        }
+      }
+    } else if (width === undefined && height === undefined && props.layout === "fill") {
+      wrapperStyle = {
+        display: "block",
+        overflow: "hidden",
+        position: "absolute",
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        boxSizing: "border-box",
+        margin: 0,
+      }
+    } else {
+      throw new Error(
+        `Image with src "${props.src}" must use "width" and "height" properties or "layout='fill'" property.`,
+      )
+    }
+
+    return (
+      //@ts-ignore
+      <div style={wrapperStyle}>
+        {sizerStyle ? (
+          //@ts-ignore
+          <div style={sizerStyle}>
+            {sizerSvg ? (
+              <img
+                style={{ maxWidth: "100%", display: "block" }}
+                alt={props.alt}
+                aria-hidden={true}
+                role="presentation"
+                src={`data:image/svg+xml;base64,${toBase64}`}
+              />
+            ) : null}
+          </div>
+        ) : null}
+        <img {...props} decoding="async" style={imgStyle} />
+      </div>
+    )
+  },
+})

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,1 +1,2 @@
 import '../styles/styles.scss';
+import './__mocks/NextImage';

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,5 +28,6 @@ module.exports = {
     'ts-jest': {
       'tsconfig': '<rootDir>/test/tsconfig.jest.json'
     }
-  }
+  },
+  coveragePathIgnorePatterns: ["<rootDir>/.storybook/__mocks/"]
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  images: {
+    domains: ['lgtm-images.lgtmeow.com'],
+  },
+}

--- a/src/__tests__/__snapshots__/Footer.stories.storyshot
+++ b/src/__tests__/__snapshots__/Footer.stories.storyshot
@@ -7,51 +7,55 @@ exports[`Storyshots src/components/Footer.tsx Show Footer With Props 1`] = `
   <div
     className="container"
   >
-    <div
-      className="level-left"
+    <nav
+      className="level"
     >
       <div
-        className="level-item breadcrumb"
+        className="level-left"
       >
-        <ul>
-          <li>
-            <a
-              href="https://policies.google.com/terms"
-              style={
-                Object {
-                  "color": "royalblue",
+        <div
+          className="level-item breadcrumb"
+        >
+          <ul>
+            <li>
+              <a
+                href="https://policies.google.com/terms"
+                style={
+                  Object {
+                    "color": "royalblue",
+                  }
                 }
-              }
-            >
-              利用規約
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://policies.google.com/privacy"
-              style={
-                Object {
-                  "color": "royalblue",
+              >
+                利用規約
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://policies.google.com/privacy"
+                style={
+                  Object {
+                    "color": "royalblue",
+                  }
                 }
-              }
-            >
-              プライバシーポリシー
-            </a>
-          </li>
-        </ul>
+              >
+                プライバシーポリシー
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
-    </div>
-    <div
-      className="level-right"
-    >
       <div
-        className="content has-text-centered"
+        className="level-right"
       >
-        <p>
-          Copyright (c) nekochans
-        </p>
+        <div
+          className="content has-text-centered"
+        >
+          <p>
+            Copyright (c) nekochans
+          </p>
+        </div>
       </div>
-    </div>
+    </nav>
   </div>
 </footer>
 `;

--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -5,29 +5,61 @@ exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Prop
   className="column is-one-third"
 >
   <div
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     style={
       Object {
-        "height": "100%",
-        "margin": "auto",
+        "cursor": "pointer",
+        "height": "300px",
+        "opacity": "1",
         "position": "relative",
-        "textAlign": "center",
       }
     }
   >
-    <img
-      alt="lgtm cat"
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      src="/cat.jpeg"
+    <div
       style={
         Object {
-          "cursor": "pointer",
-          "maxHeight": "300px",
-          "opacity": "1",
-          "padding": "0.75rem",
+          "bottom": 0,
+          "boxSizing": "border-box",
+          "display": "block",
+          "left": 0,
+          "margin": 0,
+          "overflow": "hidden",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
         }
       }
-    />
+    >
+      <img
+        decoding="async"
+        layout="fill"
+        objectFit="scale-down"
+        src="/cat.jpeg"
+        style={
+          Object {
+            "border": "none",
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "height": 0,
+            "left": 0,
+            "margin": "auto",
+            "maxHeight": "100%",
+            "maxWidth": "100%",
+            "minHeight": "100%",
+            "minWidth": "100%",
+            "objectFit": "scale-down",
+            "objectPosition": undefined,
+            "padding": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": 0,
+          }
+        }
+      />
+    </div>
   </div>
 </div>
 `;

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -12,87 +12,183 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat2.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat2.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -103,87 +199,183 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat2.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat2.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat2.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat2.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -194,87 +386,183 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat2.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat2.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
       <div
         className="column is-one-third"
       >
         <div
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
           style={
             Object {
-              "height": "100%",
-              "margin": "auto",
+              "cursor": "pointer",
+              "height": "300px",
+              "opacity": "1",
               "position": "relative",
-              "textAlign": "center",
             }
           }
         >
-          <img
-            alt="lgtm cat"
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            src="/cat.jpeg"
+          <div
             style={
               Object {
-                "cursor": "pointer",
-                "maxHeight": "300px",
-                "opacity": "1",
-                "padding": "0.75rem",
+                "bottom": 0,
+                "boxSizing": "border-box",
+                "display": "block",
+                "left": 0,
+                "margin": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
               }
             }
-          />
+          >
+            <img
+              decoding="async"
+              layout="fill"
+              objectFit="scale-down"
+              src="/cat.jpeg"
+              style={
+                Object {
+                  "border": "none",
+                  "bottom": 0,
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "height": 0,
+                  "left": 0,
+                  "margin": "auto",
+                  "maxHeight": "100%",
+                  "maxWidth": "100%",
+                  "minHeight": "100%",
+                  "minWidth": "100%",
+                  "objectFit": "scale-down",
+                  "objectPosition": undefined,
+                  "padding": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -8,87 +8,183 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
     className="column is-one-third"
   >
     <div
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
       style={
         Object {
-          "height": "100%",
-          "margin": "auto",
+          "cursor": "pointer",
+          "height": "300px",
+          "opacity": "1",
           "position": "relative",
-          "textAlign": "center",
         }
       }
     >
-      <img
-        alt="lgtm cat"
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        src="/cat.jpeg"
+      <div
         style={
           Object {
-            "cursor": "pointer",
-            "maxHeight": "300px",
-            "opacity": "1",
-            "padding": "0.75rem",
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "left": 0,
+            "margin": 0,
+            "overflow": "hidden",
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
-      />
+      >
+        <img
+          decoding="async"
+          layout="fill"
+          objectFit="scale-down"
+          src="/cat.jpeg"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": "scale-down",
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
   <div
     className="column is-one-third"
   >
     <div
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
       style={
         Object {
-          "height": "100%",
-          "margin": "auto",
+          "cursor": "pointer",
+          "height": "300px",
+          "opacity": "1",
           "position": "relative",
-          "textAlign": "center",
         }
       }
     >
-      <img
-        alt="lgtm cat"
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        src="/cat2.jpeg"
+      <div
         style={
           Object {
-            "cursor": "pointer",
-            "maxHeight": "300px",
-            "opacity": "1",
-            "padding": "0.75rem",
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "left": 0,
+            "margin": 0,
+            "overflow": "hidden",
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
-      />
+      >
+        <img
+          decoding="async"
+          layout="fill"
+          objectFit="scale-down"
+          src="/cat2.jpeg"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": "scale-down",
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
   <div
     className="column is-one-third"
   >
     <div
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
       style={
         Object {
-          "height": "100%",
-          "margin": "auto",
+          "cursor": "pointer",
+          "height": "300px",
+          "opacity": "1",
           "position": "relative",
-          "textAlign": "center",
         }
       }
     >
-      <img
-        alt="lgtm cat"
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        src="/cat.jpeg"
+      <div
         style={
           Object {
-            "cursor": "pointer",
-            "maxHeight": "300px",
-            "opacity": "1",
-            "padding": "0.75rem",
+            "bottom": 0,
+            "boxSizing": "border-box",
+            "display": "block",
+            "left": 0,
+            "margin": 0,
+            "overflow": "hidden",
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
           }
         }
-      />
+      >
+        <img
+          decoding="async"
+          layout="fill"
+          objectFit="scale-down"
+          src="/cat.jpeg"
+          style={
+            Object {
+              "border": "none",
+              "bottom": 0,
+              "boxSizing": "border-box",
+              "display": "block",
+              "height": 0,
+              "left": 0,
+              "margin": "auto",
+              "maxHeight": "100%",
+              "maxWidth": "100%",
+              "minHeight": "100%",
+              "minWidth": "100%",
+              "objectFit": "scale-down",
+              "objectPosition": undefined,
+              "padding": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,19 +8,21 @@ type Props = {
 const Footer: React.FC<Props> = ({ termsLink, privacyLink }: Props) => (
   <footer className="footer">
     <div className="container">
-      <div className="level-left">
-        <div className="level-item breadcrumb">
-          <ul>
-            <li>{termsLink}</li>
-            <li>{privacyLink}</li>
-          </ul>
+      <nav className="level">
+        <div className="level-left">
+          <div className="level-item breadcrumb">
+            <ul>
+              <li>{termsLink}</li>
+              <li>{privacyLink}</li>
+            </ul>
+          </div>
         </div>
-      </div>
-      <div className="level-right">
-        <div className="content has-text-centered">
-          <p>Copyright (c) nekochans</p>
+        <div className="level-right">
+          <div className="content has-text-centered">
+            <p>Copyright (c) nekochans</p>
+          </div>
         </div>
-      </div>
+      </nav>
     </div>
   </footer>
 );

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState } from 'react';
-import { Image } from '../domain/image';
+import Image from 'next/image';
+import { Image as ImageType } from '../domain/image';
 import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
 
 type Props = {
-  image: Image;
+  image: ImageType;
 };
 
 const ImageContent: React.FC<Props> = ({ image }: Props) => {
@@ -19,30 +20,19 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
 
   const { imageContextRef } = useClipboardMarkdown(onCopySuccess, image.url);
 
-  const imageStyles = {
-    maxHeight: '300px',
-    padding: '0.75rem',
-    cursor: 'pointer',
-    opacity,
-  };
-
   return (
     <div className="column is-one-third" key={image.id} ref={imageContextRef}>
       <div
         style={{
-          margin: 'auto',
-          height: '100%',
-          textAlign: 'center',
+          height: '300px',
           position: 'relative',
+          cursor: 'pointer',
+          opacity,
         }}
+        onMouseEnter={() => setOpacity('0.7')}
+        onMouseLeave={() => setOpacity('1')}
       >
-        <img
-          src={image.url}
-          style={imageStyles}
-          alt="lgtm cat"
-          onMouseEnter={() => setOpacity('0.7')}
-          onMouseLeave={() => setOpacity('1')}
-        />
+        <Image src={image.url} layout="fill" objectFit="scale-down" />
         {copied && (
           <div
             style={{

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -8,12 +8,27 @@
 
 @media screen and (min-width: 1216px) {
   .navbar-padding {
-    padding: 1rem 4rem;
+    padding: 1rem 4rem 2rem 4rem;
   }
 }
 
 @media screen and (min-width: 1024px) {
   .header-description-margin {
     margin-left: -0.75rem;
+  }
+}
+
+.columns {
+  margin: 0;
+}
+.columns:last-child {
+  margin-bottom: 1rem
+}
+
+@media screen and (min-width: 768px) {
+  .columns {
+    margin-left: -0.75rem;
+    margin-right: -0.75rem;
+    margin-top: -0.75rem;
   }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/33

# 関連URL
https://lgtm-cat-frontend-git-feature-issue33-nekochans.vercel.app/

# Doneの定義
画像がプリロードされるように変更されている事

# スクリーンショット
![screencapture-lgtm-cat-frontend-git-feature-issue33-nekochans-vercel-app-2021-03-20-13_06_47](https://user-images.githubusercontent.com/32682645/111858535-2a634c00-897d-11eb-9f00-5618859891a7.png)

![screencapture-lgtm-cat-frontend-git-feature-issue33-nekochans-vercel-app-2021-03-20-13_06_05](https://user-images.githubusercontent.com/32682645/111858524-1b7c9980-897d-11eb-9ef6-55ca2ef4858f.png)

# 変更点概要
- 画像がプリロードされるように、 imgタグから next/image を利用するように変更
next/image を利用する事で、画像の表示に下記の変更が発生している。
    - 画像の height を `300px` に固定 
  -> スマホで表示した際の画像間のスペースが広くなってしまったが、そこまで見た目が崩れている訳ではないので許容範囲かと思いこれ以上のスタイルの修正は行わない事にした
    - その他スタイルが悪くなった部分の微修正を行なっている

- next/image を storybook で表示するために下記の Issue を参考に next/image のモックを作成
モックにするとメンテナンスが大変になるかと思ったが、storybook 上で画像のイメージを確認できた方が良いのでモックを用意する事にした。
https://github.com/vercel/next.js/issues/18393#issuecomment-750910068

- Issue とは関係ないが、footer のメニューとコピーライトの位置がずれていたので footer 内での表示位置が揃うように footer コンポーネントを修正した。

## 補足
preview ページを PageSpeed Insights で確認したところ画像のプリロードの指摘は消えていた。
点数自体も上がっているので、next/image を利用した効果が出ていると判断して良さそう。
