### PR TITLE
画像の表示崩れを修正

### DIFF
--- a/src/__tests__/__snapshots__/ImageContext.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageContext.stories.storyshot
@@ -34,7 +34,7 @@ exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Prop
       <img
         decoding="async"
         layout="fill"
-        objectFit="scale-down"
+        objectFit="contain"
         src="/cat.jpeg"
         style={
           Object {
@@ -49,7 +49,7 @@ exports[`Storyshots src/components/ImageContext.tsx Show Image Context With Prop
             "maxWidth": "100%",
             "minHeight": "100%",
             "minWidth": "100%",
-            "objectFit": "scale-down",
+            "objectFit": "contain",
             "objectPosition": undefined,
             "padding": 0,
             "position": "absolute",

--- a/src/__tests__/__snapshots__/ImageList.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageList.stories.storyshot
@@ -41,7 +41,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat.jpeg"
               style={
                 Object {
@@ -56,7 +56,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -102,7 +102,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat2.jpeg"
               style={
                 Object {
@@ -117,7 +117,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -163,7 +163,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat.jpeg"
               style={
                 Object {
@@ -178,7 +178,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -228,7 +228,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat2.jpeg"
               style={
                 Object {
@@ -243,7 +243,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -289,7 +289,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat.jpeg"
               style={
                 Object {
@@ -304,7 +304,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -350,7 +350,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat2.jpeg"
               style={
                 Object {
@@ -365,7 +365,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -415,7 +415,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat.jpeg"
               style={
                 Object {
@@ -430,7 +430,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -476,7 +476,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat2.jpeg"
               style={
                 Object {
@@ -491,7 +491,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",
@@ -537,7 +537,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
             <img
               decoding="async"
               layout="fill"
-              objectFit="scale-down"
+              objectFit="contain"
               src="/cat.jpeg"
               style={
                 Object {
@@ -552,7 +552,7 @@ exports[`Storyshots src/components/ImageList.tsx Show Image List With Props 1`] 
                   "maxWidth": "100%",
                   "minHeight": "100%",
                   "minWidth": "100%",
-                  "objectFit": "scale-down",
+                  "objectFit": "contain",
                   "objectPosition": undefined,
                   "padding": 0,
                   "position": "absolute",

--- a/src/__tests__/__snapshots__/ImageRow.stories.storyshot
+++ b/src/__tests__/__snapshots__/ImageRow.stories.storyshot
@@ -37,7 +37,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         <img
           decoding="async"
           layout="fill"
-          objectFit="scale-down"
+          objectFit="contain"
           src="/cat.jpeg"
           style={
             Object {
@@ -52,7 +52,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
               "maxWidth": "100%",
               "minHeight": "100%",
               "minWidth": "100%",
-              "objectFit": "scale-down",
+              "objectFit": "contain",
               "objectPosition": undefined,
               "padding": 0,
               "position": "absolute",
@@ -98,7 +98,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         <img
           decoding="async"
           layout="fill"
-          objectFit="scale-down"
+          objectFit="contain"
           src="/cat2.jpeg"
           style={
             Object {
@@ -113,7 +113,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
               "maxWidth": "100%",
               "minHeight": "100%",
               "minWidth": "100%",
-              "objectFit": "scale-down",
+              "objectFit": "contain",
               "objectPosition": undefined,
               "padding": 0,
               "position": "absolute",
@@ -159,7 +159,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
         <img
           decoding="async"
           layout="fill"
-          objectFit="scale-down"
+          objectFit="contain"
           src="/cat.jpeg"
           style={
             Object {
@@ -174,7 +174,7 @@ exports[`Storyshots src/components/ImageRow.tsx Show Image Row With Props 1`] = 
               "maxWidth": "100%",
               "minHeight": "100%",
               "minWidth": "100%",
-              "objectFit": "scale-down",
+              "objectFit": "contain",
               "objectPosition": undefined,
               "padding": 0,
               "position": "absolute",

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -32,7 +32,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
         onMouseEnter={() => setOpacity('0.7')}
         onMouseLeave={() => setOpacity('1')}
       >
-        <Image src={image.url} layout="fill" objectFit="scale-down" />
+        <Image src={image.url} layout="fill" objectFit="contain" />
         {copied && (
           <div
             style={{


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/54

# 関連URL
https://lgtm-cat-frontend-git-feature-issue54-nekochans.vercel.app/

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/54 の完了の定義が満たされていること

# スクリーンショット
Safari
<img width="1437" alt="スクリーンショット 2021-03-21 1 28 37" src="https://user-images.githubusercontent.com/32682645/111877067-d8eea780-89e4-11eb-8e15-240411d07f8f.png">

Chrome
![screencapture-lgtm-cat-frontend-git-feature-issue54-nekochans-vercel-app-2021-03-21-01_29_37](https://user-images.githubusercontent.com/32682645/111877090-f885d000-89e4-11eb-8232-262af0d52193.png)

# 変更点概要
next/image に指定する`objectFit`を`contain`に変更。
Chromeでの表示した際に以前より画像が少し大きく表示されるようになってしまったが、デザインとして大きく崩れている訳ではないのでこの対応でOKとしたい。
