### PR TITLE
MarkdownコピーとランダムボタンクリックをカスタムイベントとしてGAに送信するように改修

### DIFF
--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import Image from 'next/image';
 import { Image as ImageType } from '../domain/image';
 import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
-import * as gtag from '../utils/gtag';
+import { sendCopyMarkdownEvent } from '../utils/gtag';
 
 type Props = {
   image: ImageType;
@@ -13,12 +13,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
   const [opacity, setOpacity] = useState('1');
 
   const onCopySuccess = useCallback(() => {
-    gtag.event({
-      action: 'copy_markdown',
-      category: 'copy_markdown',
-      label: 'copy_markdown_button',
-      value: 1,
-    });
+    sendCopyMarkdownEvent('copy_markdown_button');
 
     setCopied(true);
     setTimeout(() => {

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import Image from 'next/image';
 import { Image as ImageType } from '../domain/image';
 import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
+import * as gtag from '../utils/gtag';
 
 type Props = {
   image: ImageType;
@@ -12,6 +13,13 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
   const [opacity, setOpacity] = useState('1');
 
   const onCopySuccess = useCallback(() => {
+    gtag.event({
+      action: 'click',
+      category: 'copy_markdown',
+      label: 'copy_markdown_button',
+      value: 1,
+    });
+
     setCopied(true);
     setTimeout(() => {
       setCopied(false);

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -14,7 +14,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
 
   const onCopySuccess = useCallback(() => {
     gtag.event({
-      action: 'click',
+      action: 'copy_markdown',
       category: 'copy_markdown',
       label: 'copy_markdown_button',
       value: 1,

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -4,6 +4,7 @@ import { urlList } from '../constants/url';
 import { useSetAppState } from '../contexts/AppStateContext';
 import { fetchRandomImageList } from '../infrastructure/repository/ImageRepository';
 import RandomButton from '../components/RandomButton';
+import * as gtag from '../utils/gtag';
 
 const RandomButtonContainer: React.FC = () => {
   const setAppState = useSetAppState();
@@ -13,6 +14,13 @@ const RandomButtonContainer: React.FC = () => {
     try {
       const imageList = await fetchRandomImageList();
       setAppState({ imageList: imageList.images });
+
+      gtag.event({
+        action: 'click',
+        category: 'fetch_random_images',
+        label: 'fetch_random_images_button',
+        value: 1,
+      });
     } catch (e) {
       await router.push(urlList.error);
     }

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -4,7 +4,7 @@ import { urlList } from '../constants/url';
 import { useSetAppState } from '../contexts/AppStateContext';
 import { fetchRandomImageList } from '../infrastructure/repository/ImageRepository';
 import RandomButton from '../components/RandomButton';
-import * as gtag from '../utils/gtag';
+import { sendFetchRandomImages } from '../utils/gtag';
 
 const RandomButtonContainer: React.FC = () => {
   const setAppState = useSetAppState();
@@ -15,12 +15,7 @@ const RandomButtonContainer: React.FC = () => {
       const imageList = await fetchRandomImageList();
       setAppState({ imageList: imageList.images });
 
-      gtag.event({
-        action: 'fetch_random_button',
-        category: 'fetch_random_images',
-        label: 'fetch_random_images_button',
-        value: 1,
-      });
+      sendFetchRandomImages('fetch_random_images_button');
     } catch (e) {
       await router.push(urlList.error);
     }

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -16,7 +16,7 @@ const RandomButtonContainer: React.FC = () => {
       setAppState({ imageList: imageList.images });
 
       gtag.event({
-        action: 'click',
+        action: 'fetch_random_button',
         category: 'fetch_random_images',
         label: 'fetch_random_images_button',
         value: 1,

--- a/src/utils/gtag.ts
+++ b/src/utils/gtag.ts
@@ -26,3 +26,32 @@ export const event = ({ action, category, label, value }: GaEventProps) => {
     value,
   });
 };
+
+// Markdownソースがコピーされた際に実行する
+type SendCopyMarkdownEventLabel = 'copy_markdown_button';
+
+export const sendCopyMarkdownEvent = (
+  label: SendCopyMarkdownEventLabel,
+): void => {
+  event({
+    action: 'copy_markdown',
+    category: 'copy_markdown',
+    label,
+    value: 1,
+  });
+};
+
+// ランダムでLGTM画像を表示させる機能が利用された際に実行する
+
+type SendFetchRandomImagesLabel = 'fetch_random_images_button';
+
+export const sendFetchRandomImages = (
+  label: SendFetchRandomImagesLabel,
+): void => {
+  event({
+    action: 'fetch_random_images',
+    category: 'fetch_random_images',
+    label,
+    value: 1,
+  });
+};


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/47

# 関連URL
https://lgtm-cat-front-git-feature-issue47add-ga-custom-event-ne-66c302.vercel.app/

# Doneの定義
- MarkdownコピーとランダムボタンクリックがGA上で確認出来る状態になっている事

# スクリーンショット

![conversion1](https://user-images.githubusercontent.com/11032365/112109407-e1b5c800-8bf4-11eb-85c5-d02611bc5906.png)

![conversion2](https://user-images.githubusercontent.com/11032365/112109415-e4b0b880-8bf4-11eb-8b7c-ab5b322cf236.png)

# 変更点概要

GA上で `copy_markdown`, `fetch_random_images` というコンバージョンイベントを定義。

これらの操作が行われた際にコンバージョンと見なしてGA上で確認出来るようにしてある。

この方針自体が最適解ではないと思うが、広告等がない現状、少なくともこの2つの機能の利用率を上げる事は方針として大きく間違っていないと思うので、一旦この方針とした。

`gtag.event` で渡している情報のざっくりとした意味は↓を参照。

https://anagrams.jp/blog/how-to-set-up-and-use-event-tracking-in-google-analytics/#onClickanalyticsjs

- action: イベント名そのもの、ここでは作成したコンバージョンイベント `copy_markdown` , `fetch_random_images` 等を指す
- category: 上記の記事だと「イベントを分類するための名称を入れます。例えば電話タップの場合は「tel」、資料ダウンロードリンクの場合は「download」など任意の名前をつけます。」等と書いてあるが今回は何を入れたら良いか分からないので、action名と同じ値を入れた
- label: 上記の記事だと「イベントを細かく分類するための名称を入れます。例えばボタンが複数ある場合、「head_button」、「bottom_button」など任意の名前をつけます。」とあるので、UI変更等で複数のbuttonからイベントを発生させる事が出来るようになった事を想定し `SendCopyMarkdownEventLabel` や `SendFetchRandomImagesLabel` を定義して各ボタンを特定出来るようにしてある。

# レビュアーに重点的にチェックして欲しい点

イベントの設計が難しかった・・・🐱
正直これがベストと思っていないので、運用しながら最適解を探ってくという形になりそうかなと思っている！

もしイベントの設計をこうするべきとか、あれば意見をもらえるとありがたい:pray: