### PR TITLE
ローカル環境のポートを2222に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ lgtm-cat（サービス名 LGTMeow https://lgtmeow.com  のフロントエンド
 `.env`を作成し、下記を設定してください。
 
 ```
-NEXT_PUBLIC_APP_URL=本アプリケーションのURL、ローカルの場合は http://localhost:3000
+NEXT_PUBLIC_APP_URL=本アプリケーションのURL、ローカルの場合は http://localhost:2222
 NEXT_PUBLIC_GA_MEASUREMENT_ID=Google Analytics（次世代の4）の測定ID（G-から始まるID）を指定
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ NEXT_PUBLIC_GA_MEASUREMENT_ID=Google Analytics（次世代の4）の測定ID（G
 
 環境変数は以下の環境毎に必要です。
 
-- Production（本番環境）
-- Preview（GitHubのブランチにプッシュされる度に一時的に生成される環境）
-- Development（Vercelのプロジェクトを作成すると自動で生成される環境）
+- Production
+  - 本番環境
+- Preview
+  - GitHubのブランチにプッシュされる度に一時的に生成される環境
+- Development
+  - [vercel dev](https://vercel.com/docs/cli#commands/dev) コマンドでローカル環境を起動した場合、この環境変数が利用されます。
 
 ※ 全環境で共有な環境変数を設定する事も可能です。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "with-typescript",
   "version": "1.0.0",
   "scripts": {
-    "dev": "next",
+    "dev": "next -p 2222",
     "build": "next build",
     "start": "next start",
     "type-check": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "with-typescript",
+  "name": "lgtm-cat-frontend",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
     "dev": "next -p 2222",
     "build": "next build",
@@ -70,6 +71,5 @@
     "stylelint-order": "^4.1.0",
     "ts-jest": "^26.5.1",
     "typescript": "4.1.5"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/49

# 関連URL
http://localhost:2222

# Doneの定義
- https://github.com/nekochans/lgtm-cat-frontend/issues/49 の完了の定義を満たしている事

# 変更点概要
ローカルサーバーのポートを2222に変更。

このPRマージ後は `.env` の `NEXT_PUBLIC_APP_URL` も `http://localhost:2222` に設定する必要がある。

それから、PRの主目的とは関係ないが以下の修正も実施。

- `package.json` の説明等を適切な値に修正（詳しくは https://github.com/nekochans/lgtm-cat-frontend/pull/61/commits/d52443039b14dc821339e9eef00460edf91127db のコミットメッセージを参照）
- READMEのVercel上の環境変数についての説明が間違っていたので修正（https://github.com/nekochans/lgtm-cat-frontend/pull/61/commits/de5aae2af0cc8a0d09dbeca79b6d71419cf3ad75）