### PR TITLE
404エラーページを作成

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 type Props = {
   title: string;
-  message: string;
+  message: ReactNode;
   topLink: ReactNode;
 };
 

--- a/src/components/ErrorLayout.tsx
+++ b/src/components/ErrorLayout.tsx
@@ -1,0 +1,49 @@
+import React, { ReactNode } from 'react';
+import Head from 'next/head';
+import Link from 'next/link';
+import Footer from './Footer';
+import SimpleHeader from './SimpleHeader';
+import { pathList } from '../constants/url';
+
+type Props = {
+  children: ReactNode;
+  title: string;
+};
+
+const ErrorLayout: React.FC<Props> = ({ children, title }: Props) => (
+  <div className="hero is-fullheight">
+    <Head>
+      <title>{title}</title>
+      <meta charSet="utf-8" />
+      <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      <meta name="robots" content="noindex" />
+    </Head>
+    <SimpleHeader
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a className="navbar-item">
+            <p className="is-size-4 has-text-black">LGTMeow</p>
+          </a>
+        </Link>
+      }
+    />
+    {children}
+    <Footer
+      termsLink={
+        <Link href={pathList.terms}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>利用規約</a>
+        </Link>
+      }
+      privacyLink={
+        <Link href={pathList.privacy}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>プライバシーポリシー</a>
+        </Link>
+      }
+    />
+  </div>
+);
+
+export default ErrorLayout;

--- a/src/constants/metaTag.ts
+++ b/src/constants/metaTag.ts
@@ -6,6 +6,8 @@ const appName: AppName = 'LGTMeow';
 
 const defaultTitle = appName;
 
+export const custom404title = `ページが見つかりません | ${appName}}`;
+
 const defaultDescription =
   'LGTMeowは可愛い猫のLGTM画像を共有出来るサービスです。';
 

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { NextPage } from 'next';
+import Link from 'next/link';
+import Error from '../components/Error';
+import { pathList } from '../constants/url';
+import ErrorLayout from '../components/ErrorLayout';
+import { custom404title } from '../constants/metaTag';
+
+const Custom404: NextPage = () => (
+  <ErrorLayout title={custom404title}>
+    <Error
+      title="404"
+      message={
+        <p>
+          お探しのページが見つかりません。
+          <br />
+          URLが間違っている、もしくは移動または削除された可能性があります。
+        </p>
+      }
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>TOPページへ</a>
+        </Link>
+      }
+    />
+  </ErrorLayout>
+);
+
+export default Custom404;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/40

# 関連URL
https://lgtm-cat-frontend-git-feature-issue40-nekochans.vercel.app/404

# Doneの定義
- pages/404.ts が作成され共通のエラーコンポーネントを呼び出すように改修されている事
- 作成したカスタム404ページにnoindexが設定されている事

# スクリーンショット
![screencapture-lgtm-cat-frontend-git-feature-issue40-nekochans-vercel-app-404-2021-03-27-22_51_42](https://user-images.githubusercontent.com/32682645/112722876-2e7c0480-8f4f-11eb-9feb-533ee5b15b8c.png)
![screencapture-lgtm-cat-frontend-git-feature-issue40-nekochans-vercel-app-404-2021-03-27-22_52_20](https://user-images.githubusercontent.com/32682645/112722883-3471e580-8f4f-11eb-9d34-db50a59ecbbb.png)


# 変更点概要
404ページを作成。
`src/components/ErrorLayout.tsx`を新規で作成し、noindexを設定。OGPの設定も不要だと考え、OGPの設定も行なっていない。

既存の`src/components/SimpleLayout.tsx`をエラーページでも利用できるように修正することも考えたが、noindex だけでなく OGPの設定など考慮する部分が多く、複雑になってしまう割にメリットが無いように感じたので別のレイアウトを作成した。

# レビュアーに重点的にチェックして欲しい点
- メッセージは適切かどうか