### PR TITLE
カスタムエラーページを作成

### DIFF
--- a/src/constants/metaTag.ts
+++ b/src/constants/metaTag.ts
@@ -7,6 +7,7 @@ const appName: AppName = 'LGTMeow';
 const defaultTitle = appName;
 
 export const custom404title = `ページが見つかりません | ${appName}}`;
+export const customErrorTitle = `エラー | ${appName}`;
 
 const defaultDescription =
   'LGTMeowは可愛い猫のLGTM画像を共有出来るサービスです。';

--- a/src/constants/metaTag.ts
+++ b/src/constants/metaTag.ts
@@ -6,7 +6,7 @@ const appName: AppName = 'LGTMeow';
 
 const defaultTitle = appName;
 
-export const custom404title = `ページが見つかりません | ${appName}}`;
+export const custom404title = `ページが見つかりません | ${appName}`;
 export const customErrorTitle = `エラー | ${appName}`;
 
 const defaultDescription =

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NextPage } from 'next';
+import Link from 'next/link';
+import Error from '../components/Error';
+import { pathList } from '../constants/url';
+import ErrorLayout from '../components/ErrorLayout';
+import { customErrorTitle } from '../constants/metaTag';
+
+const Custom404: NextPage = () => (
+  <ErrorLayout title={customErrorTitle}>
+    <Error
+      title="Error"
+      message="エラーが発生しました。お手数ですが、時間がたってから再度お試し下さい。"
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>TOPページへ</a>
+        </Link>
+      }
+    />
+  </ErrorLayout>
+);
+
+export default Custom404;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -6,7 +6,7 @@ import { pathList } from '../constants/url';
 import ErrorLayout from '../components/ErrorLayout';
 import { customErrorTitle } from '../constants/metaTag';
 
-const Custom404: NextPage = () => (
+const CustomError: NextPage = () => (
   <ErrorLayout title={customErrorTitle}>
     <Error
       title="Error"
@@ -21,4 +21,4 @@ const Custom404: NextPage = () => (
   </ErrorLayout>
 );
 
-export default Custom404;
+export default CustomError;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/41

# 関連URL
https://lgtm-cat-frontend-git-feature-issue41-nekochans.vercel.app/404

# Doneの定義
- 独自のエラーページが作成され、共通のエラーコンポーネントを呼び出すように改修されている事

# スクリーンショット
![screencapture-localhost-2222-error-2021-03-30-23_44_54](https://user-images.githubusercontent.com/32682645/113009438-e78e4900-91b2-11eb-8924-0d6618edc1c8.png)

# 変更点概要
pages/500.js でエラーページを定義するためにはmv10.0.8以上のバージョンを指定する必要があった。
> Add generating static 500 status page: #22139
https://github.com/vercel/next.js/releases/tag/v10.0.8c

v10.0.6を利用しているので、`pages/_error.tsx`を作成し共通のエラーコンポーネントを表示するように修正を行なった。

下記の通り、動作確認を行なった。
一時期に `getServerSideProps` でErrorをthrow処理するを追加し、エラーページを表示させて期待通りのエラーページになっていることを確認。

Issueとは関係ないが、404エラーページのタイトルに`}`が含まれていたので削除した。
https://github.com/nekochans/lgtm-cat-frontend/pull/67/commits/2212b8e513a90a2199909a6db2364baa8e45491a