### PR TITLE
モバイル端末で表示した際の余白を追加するため MarkdownContents コンポーネントのスタイルを修正

### DIFF
--- a/src/__tests__/__snapshots__/MarkdownContents.stories.storyshot
+++ b/src/__tests__/__snapshots__/MarkdownContents.stories.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots src/components/MarkdownContents.tsx Show Markdown Contents W
   }
 >
   <div
-    className="content mb-6"
+    className="content mb-6 mx-3"
   >
     <h1>
       🐱ねこの種類🐱

--- a/src/components/MarkdownContents.tsx
+++ b/src/components/MarkdownContents.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 const MarkdownContents: React.FC<Props> = ({ markdown }: Props) => (
   <div className="container" style={{ display: 'block' }}>
-    <div className="content mb-6">
+    <div className="content mb-6 mx-3">
       <ReactMarkdown source={markdown} />
     </div>
   </div>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/63

# 関連URL
https://lgtm-cat-frontend-git-feature-issue63-nekochans.vercel.app/privacy
https://lgtm-cat-frontend-git-feature-issue63-nekochans.vercel.app/terms

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/63 の完了条件が満たされていること

# スクリーンショット
<img width="388" alt="スクリーンショット 2021-04-01 0 09 13" src="https://user-images.githubusercontent.com/32682645/113167267-8633ac00-927e-11eb-84c7-28aac2376307.png">
<img width="395" alt="スクリーンショット 2021-04-01 0 08 57" src="https://user-images.githubusercontent.com/32682645/113167321-95b2f500-927e-11eb-9fd1-7c90e561a0c7.png">

# 変更点概要
MarkdownContents コンポーネントのスタイルを修正。
bulmaを利用して、marginを追加している。
参考: https://bulma.io/documentation/helpers/spacing-helpers/