### PR TITLE
モバイルでLGTM画像を選択した際のスタイルを選択前の状態に戻す

### DIFF
--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -15,6 +15,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
   const onCopySuccess = useCallback(() => {
     sendCopyMarkdownEvent('copy_markdown_button');
 
+    setOpacity('1');
     setCopied(true);
     setTimeout(() => {
       setCopied(false);

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -41,6 +41,7 @@ const ImageContent: React.FC<Props> = ({ image }: Props) => {
           <div
             style={{
               position: 'absolute',
+              textAlign: 'center',
               bottom: '10%',
               left: '50%',
               color: 'white',


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/66

# 関連URL
https://lgtm-cat-frontend-git-feature-issue66-nekochans.vercel.app/

# スクリーンショット
<img width="347" alt="スクリーンショット 2021-04-02 22 28 20" src="https://user-images.githubusercontent.com/32682645/113419630-c9b72300-9402-11eb-946c-6dc6ac81b14b.png">


# Doneの定義
- モバイルでLGTM画像をしたした際のスタイルが選択前の状態に戻っていること

# 変更点概要

モバイルでLGTM画像を選択(タップ)した際にopacityが`0.7`に設定され、タップ後も画像が薄くなったまま状態になっていたので、LGTM画像を選択した際にopacityを`1`を設定する処理を追加。

PCで操作した際の動作も変わってしまうが、opacityを`1` に戻した状態で「Github Markdown Copied!」のメッセージが表示された方が見やすいので、この対応方法とした。

モバイルで画像選択時に表示される「Github Markdown Copied!」のメッセージが左寄りになってしまっていたので、中央に表示されるようにスタイルの変更を行なった。

# レビュアーに重点的にチェックして欲しい点
画像選択時の表示に問題ないか