### PR TITLE
APIのパスを相対パスで定義するように変更

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -1,7 +1,6 @@
 const appBaseUrl = (): string =>
   process.env.NEXT_PUBLIC_APP_URL ? process.env.NEXT_PUBLIC_APP_URL : '';
 
-// eslint-disable-next-line import/prefer-default-export
 export const urlList = {
   top: appBaseUrl(),
   ogpImg: `${appBaseUrl()}/ogp.webp`,
@@ -9,6 +8,8 @@ export const urlList = {
   privacy: `${appBaseUrl()}/privacy`,
   error: `${appBaseUrl()}/error`,
 } as const;
+
+export const apiList = { fetchLgtmImages: '/api/lgtm/images' };
 
 export const pathList = {
   top: '/',

--- a/src/infrastructure/repository/ImageRepository.ts
+++ b/src/infrastructure/repository/ImageRepository.ts
@@ -1,12 +1,11 @@
 import { ImageList } from '../../domain/image';
-import { urlList } from '../../constants/url';
 import { FetchRandomImageList } from '../../domain/repository';
 import FetchRandomImageListError from '../../domain/error/FetchRandomImageListError';
+import { apiList } from '../../constants/url';
 
 // eslint-disable-next-line import/prefer-default-export
 export const fetchRandomImageList: FetchRandomImageList = async () => {
-  const url = `${urlList.top}/api/lgtm/images`;
-  const response = await fetch(url);
+  const response = await fetch(apiList.fetchLgtmImages);
 
   if (!response.ok) {
     throw new FetchRandomImageListError();


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/58

# 関連URL
https://lgtm-cat-frontend-git-feature-issue58-nekochans.vercel.app/

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/58 の完了の定義が満たされていること

# 変更点概要
APIのパスを相対パスに変更。
パスは、`src/constants/url.ts`に定義した。
