### PR TITLE
トップページのヘッダーのサービス名のリンクを押下した際の挙動を修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { GetStaticProps } from 'next';
 import Layout from '../components/Layout';
 import { metaTagList } from '../constants/metaTag';
@@ -14,7 +14,11 @@ type Props = {
 
 const IndexPage: React.FC<Props> = ({ imageList }: Props) => {
   const setAppState = useSetAppState();
-  setAppState({ imageList, isFailedFetchImages: false });
+
+  useEffect(() => {
+    setAppState({ imageList, isFailedFetchImages: false });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Layout metaTag={metaTagList().top}>


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/50

# 関連URL
https://lgtm-cat-frontend-git-feature-issue50-nekochans.vercel.app/

# Doneの定義
- https://github.com/nekochans/lgtm-cat-frontend/issues/50 の完了の定義を満たしている事

# 変更点概要

Headerの「LGTMeow」リンクをクリックした際も `getStaticProps` が動作して `imageList` が更新される、2回目以降にリンクをクリックした際は `IndexPage` がレンダリング済なので `imageList` が更新されない。

その為 https://github.com/nekochans/lgtm-cat-frontend/issues/50 のような動きになっていた。

`useEffect` 内で `setAppState` を実施するように改修を行った、第2引数を空の配列にする事で一度だけ `setAppState` が呼ばれるようになったので `IndexPage` へのリンクを何回クリックしても `setAppState` が呼ばれないので `imageList` が更新される事はなくなった。

ちなみにブラウザ側のコンソールを見ると、以下の警告が出ていた、この警告も本件の修正によって出なくなった。

```
Warning: Cannot update a component from inside the function body of a different component.
```

# 補足情報
修正の際に参考した記事。

https://qiita.com/koichiba/items/e0d772022baf94d48419
