### PR TITLE
LGTM画像更新用のボタンのテキストを変更

### DIFF
--- a/src/__tests__/__snapshots__/Header.stories.storyshot
+++ b/src/__tests__/__snapshots__/Header.stories.storyshot
@@ -45,7 +45,7 @@ exports[`Storyshots src/components/Header.tsx Show Header 1`] = `
             }
             type="submit"
           >
-            ランダム
+            他の猫ちゃんを表示
           </button>
         </div>
       </div>

--- a/src/__tests__/__snapshots__/RandomButton.stories.storyshot
+++ b/src/__tests__/__snapshots__/RandomButton.stories.storyshot
@@ -11,6 +11,6 @@ exports[`Storyshots src/components/RandomButton.tsx Show Random Button With Prop
   }
   type="submit"
 >
-  ランダム
+  他の猫ちゃんを表示
 </button>
 `;

--- a/src/components/RandomButton.tsx
+++ b/src/components/RandomButton.tsx
@@ -11,7 +11,7 @@ const RandomButton: React.FC<Props> = ({ handleRandom }: Props) => (
     type="submit"
     onClick={() => handleRandom()}
   >
-    ランダム
+    他の猫ちゃんを表示
   </button>
 );
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/81

# 関連URL
https://lgtm-cat-frontend-git-feature-issue81-nekochans.vercel.app/

# Doneの定義
https://github.com/nekochans/lgtm-cat-frontend/issues/81 の完了の定義が満たされていること

# スクリーンショット
<img width="1283" alt="スクリーンショット 2021-05-24 22 59 56" src="https://user-images.githubusercontent.com/32682645/119358661-cd20a980-bce3-11eb-8e2d-8dddd664de36.png">

<img width="365" alt="スクリーンショット 2021-05-24 23 00 36" src="https://user-images.githubusercontent.com/32682645/119358732-e0cc1000-bce3-11eb-8f0e-df39f9e44ea4.png">


# 変更点概要
ボタンのテキストを「他の猫ちゃんを表示」に変更
