### PR TITLE
画像アップロード用ページデザインを追加

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<script
+  defer
+  src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"
+></script>

--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等のリアルな猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary mb-6"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+</div>
+`;

--- a/src/components/CatImageUploadDescription.tsx
+++ b/src/components/CatImageUploadDescription.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const CatImageUploadDescription: React.FC = () => (
+  <div className="content">
+    <h1>猫ちゃん画像をアップロード</h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱
+      利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>拡張子が png, jpg, jpeg の画像のみアップロード出来ます。</li>
+      <li>猫が写っていない画像はアップロード出来ません。</li>
+      <li>人の顔がはっきり写っている画像はアップロード出来ません。</li>
+      <li>
+        猫のイラスト等のリアルな猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+);
+
+export default CatImageUploadDescription;

--- a/src/components/CatImageUploadError.tsx
+++ b/src/components/CatImageUploadError.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 type Props = {
   message: string;
 };

--- a/src/components/CatImageUploadError.tsx
+++ b/src/components/CatImageUploadError.tsx
@@ -1,0 +1,14 @@
+type Props = {
+  message: string;
+};
+
+const CatImageUploadError: React.FC<Props> = ({ message }: Props) => (
+  <article className="message is-danger">
+    <div className="message-header">
+      <p>エラーが発生しました。</p>
+    </div>
+    <div className="message-body">{message}</div>
+  </article>
+);
+
+export default CatImageUploadError;

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import CatImageUploadForm from './CatImageUploadForm';
+
+export default {
+  title: 'src/components/CatImageUploadForm.tsx',
+  component: Error,
+  includeStories: ['showCatImageUploadForm'],
+};
+
+export const showCatImageUploadForm = (): JSX.Element => <CatImageUploadForm />;

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -32,11 +32,15 @@ const CatImageUploadForm: React.FC = () => {
 
       setErrorMessage('');
       setImagePreviewUrl(url);
+      // TODO 以下の課題で https://github.com/nekochans/lgtm-cat-api/pull/8 で作成中のAPIにリクエストする処理を追加
+      // https://github.com/nekochans/lgtm-cat-frontend/issues/76
     }
   };
 
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    // TODO 以下の課題で window.confirm の利用はやめてちゃんとしたモーダルを使った処理に変更する
+    // https://github.com/nekochans/lgtm-cat-frontend/issues/93
     if (window.confirm('この画像をアップロードします。よろしいですか？')) {
       setUploaded(true);
       setErrorMessage('');

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -11,11 +11,12 @@ const CatImageUploadForm: React.FC = () => {
   const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
     if (e.target.files && e.target.files.length > 0) {
-      if (!isValidFileType(e.target.files[0].type)) {
+      const file = e.target.files[0];
+      if (!isValidFileType(file.type)) {
         return;
       }
 
-      const url = URL.createObjectURL(e.target.files[0]);
+      const url = URL.createObjectURL(file);
 
       setUploadedCatImageUrl(url);
     }

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -3,7 +3,7 @@ import React, { useState, ChangeEvent } from 'react';
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 
 const CatImageUploadForm: React.FC = () => {
-  const [uploadedCatImageUrl, setUploadedCatImageUrl] = useState<string>();
+  const [imagePreviewUrl, setImagePreviewUrl] = useState<string>();
 
   const isValidFileType = (fileType: string): boolean =>
     acceptedTypes.includes(fileType);
@@ -18,7 +18,7 @@ const CatImageUploadForm: React.FC = () => {
 
       const url = URL.createObjectURL(file);
 
-      setUploadedCatImageUrl(url);
+      setImagePreviewUrl(url);
     }
   };
 
@@ -46,8 +46,8 @@ const CatImageUploadForm: React.FC = () => {
           アップロード
         </button>
       </form>
-      {uploadedCatImageUrl ? (
-        <img src={uploadedCatImageUrl} alt="preview" />
+      {imagePreviewUrl ? (
+        <img src={imagePreviewUrl} alt="uploadImagePreview" />
       ) : (
         ''
       )}

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState, ChangeEvent } from 'react';
+import UploadCatImagePreview from './UploadCatImagePreview';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 
@@ -47,7 +48,7 @@ const CatImageUploadForm: React.FC = () => {
         </button>
       </form>
       {imagePreviewUrl ? (
-        <img src={imagePreviewUrl} alt="uploadImagePreview" />
+        <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
       ) : (
         ''
       )}

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -2,12 +2,14 @@ import React, { useState, ChangeEvent } from 'react';
 import UploadCatImagePreview from './UploadCatImagePreview';
 import CatImageUploadDescription from './CatImageUploadDescription';
 import CatImageUploadError from './CatImageUploadError';
+import CatImageUploadSuccessMessage from './CatImageUploadSuccessMessage';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 
 const CatImageUploadForm: React.FC = () => {
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [uploaded, setUploaded] = useState<boolean>();
 
   const isValidFileType = (fileType: string): boolean =>
     acceptedTypes.includes(fileType);
@@ -16,6 +18,7 @@ const CatImageUploadForm: React.FC = () => {
     e.preventDefault();
     if (e.target.files && e.target.files.length > 0) {
       const file = e.target.files[0];
+      setUploaded(false);
       if (!isValidFileType(file.type)) {
         setErrorMessage(
           `${file.type} の画像は許可されていません。png, jpg, jpeg の画像のみアップロード出来ます。`,
@@ -32,10 +35,23 @@ const CatImageUploadForm: React.FC = () => {
     }
   };
 
+  const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (window.confirm('この画像をアップロードします。よろしいですか？')) {
+      setUploaded(true);
+      setErrorMessage('');
+      setImagePreviewUrl('');
+
+      return true;
+    }
+
+    return false;
+  };
+
   return (
     <div className="container">
       <CatImageUploadDescription />
-      <form method="post">
+      <form method="post" onSubmit={handleOnSubmit}>
         <div className="file has-name is-boxed">
           <label className="file-label mb-3" htmlFor="cat-image-upload">
             <input
@@ -53,7 +69,11 @@ const CatImageUploadForm: React.FC = () => {
             </span>
           </label>
         </div>
-        <button className="button is-primary mb-6" type="submit">
+        <button
+          className="button is-primary mb-6"
+          type="submit"
+          disabled={!(imagePreviewUrl && errorMessage === '')}
+        >
           アップロードする
         </button>
       </form>
@@ -63,6 +83,7 @@ const CatImageUploadForm: React.FC = () => {
         ''
       )}
       {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
+      {uploaded ? <CatImageUploadSuccessMessage /> : ''}
     </div>
   );
 };

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -1,24 +1,57 @@
-import React from 'react';
+import React, { useState, ChangeEvent } from 'react';
 
-const CatImageUploadForm: React.FC = () => (
-  <form>
-    <div className="file has-name is-boxed">
-      <label className="file-label" htmlFor="cat-image-upload">
-        <input
-          className="file-input"
-          type="file"
-          name="uploadedCatImage"
-          id="cat-image-upload"
-        />
-        <span className="file-cta">
-          <span className="file-icon">
-            <i className="fas fa-upload" />
-          </span>
-          <span className="file-label">猫ちゃん画像をアップロード</span>
-        </span>
-      </label>
-    </div>
-  </form>
-);
+const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
+
+const CatImageUploadForm: React.FC = () => {
+  const [uploadedCatImageUrl, setUploadedCatImageUrl] = useState<string>();
+
+  const isValidFileType = (fileType: string): boolean =>
+    acceptedTypes.includes(fileType);
+
+  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    if (e.target.files && e.target.files.length > 0) {
+      if (!isValidFileType(e.target.files[0].type)) {
+        return;
+      }
+
+      const url = URL.createObjectURL(e.target.files[0]);
+
+      setUploadedCatImageUrl(url);
+    }
+  };
+
+  return (
+    <>
+      <form method="post">
+        <div className="file has-name is-boxed">
+          <label className="file-label" htmlFor="cat-image-upload">
+            <input
+              className="file-input"
+              type="file"
+              name="uploadedCatImage"
+              id="cat-image-upload"
+              onChange={handleFileUpload}
+            />
+            <span className="file-cta">
+              <span className="file-icon">
+                <i className="fas fa-upload" />
+              </span>
+              <span className="file-label">猫ちゃん画像を選択</span>
+            </span>
+          </label>
+        </div>
+        <button className="button is-primary" type="submit">
+          アップロード
+        </button>
+      </form>
+      {uploadedCatImageUrl ? (
+        <img src={uploadedCatImageUrl} alt="preview" />
+      ) : (
+        ''
+      )}
+    </>
+  );
+};
 
 export default CatImageUploadForm;

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, ChangeEvent } from 'react';
 import UploadCatImagePreview from './UploadCatImagePreview';
+import CatImageUploadDescription from './CatImageUploadDescription';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 
@@ -24,7 +25,8 @@ const CatImageUploadForm: React.FC = () => {
   };
 
   return (
-    <>
+    <div className="container">
+      <CatImageUploadDescription />
       <form method="post">
         <div className="file has-name is-boxed">
           <label className="file-label" htmlFor="cat-image-upload">
@@ -44,7 +46,7 @@ const CatImageUploadForm: React.FC = () => {
           </label>
         </div>
         <button className="button is-primary" type="submit">
-          アップロード
+          アップロードする
         </button>
       </form>
       {imagePreviewUrl ? (
@@ -52,7 +54,7 @@ const CatImageUploadForm: React.FC = () => {
       ) : (
         ''
       )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -1,11 +1,13 @@
 import React, { useState, ChangeEvent } from 'react';
 import UploadCatImagePreview from './UploadCatImagePreview';
 import CatImageUploadDescription from './CatImageUploadDescription';
+import CatImageUploadError from './CatImageUploadError';
 
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
 
 const CatImageUploadForm: React.FC = () => {
   const [imagePreviewUrl, setImagePreviewUrl] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   const isValidFileType = (fileType: string): boolean =>
     acceptedTypes.includes(fileType);
@@ -15,11 +17,17 @@ const CatImageUploadForm: React.FC = () => {
     if (e.target.files && e.target.files.length > 0) {
       const file = e.target.files[0];
       if (!isValidFileType(file.type)) {
+        setErrorMessage(
+          `${file.type} の画像は許可されていません。png, jpg, jpeg の画像のみアップロード出来ます。`,
+        );
+        setImagePreviewUrl('');
+
         return;
       }
 
       const url = URL.createObjectURL(file);
 
+      setErrorMessage('');
       setImagePreviewUrl(url);
     }
   };
@@ -29,7 +37,7 @@ const CatImageUploadForm: React.FC = () => {
       <CatImageUploadDescription />
       <form method="post">
         <div className="file has-name is-boxed">
-          <label className="file-label" htmlFor="cat-image-upload">
+          <label className="file-label mb-3" htmlFor="cat-image-upload">
             <input
               className="file-input"
               type="file"
@@ -45,7 +53,7 @@ const CatImageUploadForm: React.FC = () => {
             </span>
           </label>
         </div>
-        <button className="button is-primary" type="submit">
+        <button className="button is-primary mb-6" type="submit">
           アップロードする
         </button>
       </form>
@@ -54,6 +62,7 @@ const CatImageUploadForm: React.FC = () => {
       ) : (
         ''
       )}
+      {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
     </div>
   );
 };

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const CatImageUploadForm: React.FC = () => (
+  <form>
+    <div className="file has-name is-boxed">
+      <label className="file-label" htmlFor="cat-image-upload">
+        <input
+          className="file-input"
+          type="file"
+          name="uploadedCatImage"
+          id="cat-image-upload"
+        />
+        <span className="file-cta">
+          <span className="file-icon">
+            <i className="fas fa-upload" />
+          </span>
+          <span className="file-label">猫ちゃん画像をアップロード</span>
+        </span>
+      </label>
+    </div>
+  </form>
+);
+
+export default CatImageUploadForm;

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const CatImageUploadSuccessMessage: React.FC = () => (
+  <div className="content">
+    <article className="message is-success">
+      <div className="message-header">
+        <p>アップロードに成功しました🐱！</p>
+      </div>
+      <div className="message-body">
+        アップロードされた画像を審査していますので、少々お待ち下さい。
+        審査に合格していれば以下のMarkdownソースで生成されたLGTM画像を確認出来ます。
+      </div>
+    </article>
+    <blockquote>
+      [![LGTMeow](https://lgtm-images.lgtmeow.com/2021/03/16/22/03b4b6a8-931c-47cf-b2e5-ff8218a67b08.webp)](https://lgtmeow.com)
+    </blockquote>
+  </div>
+);
+
+export default CatImageUploadSuccessMessage;

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+// TODO 以下の課題でAPIの返り値からMarkdownソースを生成する形に変更
+// https://github.com/nekochans/lgtm-cat-frontend/issues/76
+// TODO blockquote をクリックしたらクリップボードにソースをコピーするように変更
 const CatImageUploadSuccessMessage: React.FC = () => (
   <div className="content">
     <article className="message is-success">

--- a/src/components/UploadCatImagePreview.tsx
+++ b/src/components/UploadCatImagePreview.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 
 const UploadCatImagePreview: React.FC<Props> = ({ imagePreviewUrl }: Props) => (
-  <figure className="image is-square">
+  <figure className="image">
     <img src={imagePreviewUrl} alt="uploadImagePreview" />
   </figure>
 );

--- a/src/components/UploadCatImagePreview.tsx
+++ b/src/components/UploadCatImagePreview.tsx
@@ -5,7 +5,9 @@ type Props = {
 };
 
 const UploadCatImagePreview: React.FC<Props> = ({ imagePreviewUrl }: Props) => (
-  <img src={imagePreviewUrl} alt="uploadImagePreview" />
+  <figure className="image is-square">
+    <img src={imagePreviewUrl} alt="uploadImagePreview" />
+  </figure>
 );
 
 export default UploadCatImagePreview;

--- a/src/components/UploadCatImagePreview.tsx
+++ b/src/components/UploadCatImagePreview.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type Props = {
+  imagePreviewUrl: string;
+};
+
+const UploadCatImagePreview: React.FC<Props> = ({ imagePreviewUrl }: Props) => (
+  <img src={imagePreviewUrl} alt="uploadImagePreview" />
+);
+
+export default UploadCatImagePreview;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,6 +42,10 @@ export default class CustomDocument extends Document {
               `,
             }}
           />
+          <script
+            defer
+            src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"
+          />
         </Head>
         <body>
           <Main />

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { metaTagList } from '../constants/metaTag';
-import DefaultLayout from '../layouts/DefaultLayout';
 import CatImageUploadForm from '../components/CatImageUploadForm';
+import SimpleLayout from '../layouts/SimpleLayout';
 
 const UploadPage: React.FC = () => (
-  <DefaultLayout metaTag={metaTagList().top}>
+  <SimpleLayout metaTag={metaTagList().top}>
     <CatImageUploadForm />
-  </DefaultLayout>
+  </SimpleLayout>
 );
 
 export default UploadPage;

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { metaTagList } from '../constants/metaTag';
+import DefaultLayout from '../layouts/DefaultLayout';
+import CatImageUploadForm from '../components/CatImageUploadForm';
+
+const UploadPage: React.FC = () => (
+  <DefaultLayout metaTag={metaTagList().top}>
+    <CatImageUploadForm />
+  </DefaultLayout>
+);
+
+export default UploadPage;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/75

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue75add-uploa-729d45-nekochans.vercel.app/upload

# Done の定義

- 画像アップロードから完了までの流れが確認出来るだけのフロントエンドの実装が完了している事

# スクリーンショット

## 1. プレビュー

![Preview](https://user-images.githubusercontent.com/11032365/124486215-539ecf80-dde8-11eb-879d-3fb2d8df4a7c.png)

## 2. 確認

![confirm](https://user-images.githubusercontent.com/11032365/124486246-5a2d4700-dde8-11eb-8148-de153bfecae7.png)

## 3. アップロード成功

![Success](https://user-images.githubusercontent.com/11032365/124486267-5ef1fb00-dde8-11eb-99e1-3dbec4a138b8.png)

### 4. エラー

![Error](https://user-images.githubusercontent.com/11032365/124486294-67e2cc80-dde8-11eb-88bc-a761ff5032bb.png)

# 変更点概要

`CatImageUploadForm` Componentを中心にアップロード完了後まで確認する為に必要なComponentを実装。

[React Hook Form](https://react-hook-form.com/jp/) 等は今の時点では使わない予定。（もし他にもFormを使うようなページがたくさん追加される、もしくは処理が複雑になった時点で検討で良いと思っている）

# レビュアーに重点的にチェックして欲しい点

細かいところで、実装が不十分なところがあるけど、アップロードまでのユーザー体験が不自然じゃないかと、文言等が適切かどうかを見てもらえると:pray:

# 補足情報

TODOコメントにもあるが、実装のボリュームがそれなりに大きいので、別のissueで対応予定。

- https://github.com/nekochans/lgtm-cat-frontend/issues/76
- https://github.com/nekochans/lgtm-cat-frontend/issues/94
- https://github.com/nekochans/lgtm-cat-frontend/issues/93
- https://github.com/nekochans/lgtm-cat-frontend/issues/95