### PR TITLE
DefaultLayout内にアップロードページへのリンクを追加

### DIFF
--- a/src/__tests__/__snapshots__/Header.stories.storyshot
+++ b/src/__tests__/__snapshots__/Header.stories.storyshot
@@ -35,6 +35,16 @@ exports[`Storyshots src/components/Header.tsx Show Header 1`] = `
             }
           }
         >
+          <a
+            className="navbar-item button"
+            href="https://github.com/nekochans/lgtm-cat-frontend"
+          >
+            <p
+              className="has-text-black"
+            >
+              猫ちゃん画像をアップロード
+            </p>
+          </a>
           <button
             className="button is-outlined"
             onClick={[Function]}

--- a/src/__tests__/__snapshots__/Header.stories.storyshot
+++ b/src/__tests__/__snapshots__/Header.stories.storyshot
@@ -34,29 +34,69 @@ exports[`Storyshots src/components/Header.tsx Show Header 1`] = `
               "marginLeft": "auto",
             }
           }
+        />
+        <button
+          aria-expanded="false"
+          aria-label="menu"
+          className="navbar-burger burger "
+          data-target="navbar-burger-menu"
+          onClick={[Function]}
+          role="button"
+          type="button"
         >
-          <a
-            className="navbar-item button"
-            href="https://github.com/nekochans/lgtm-cat-frontend"
+          <span
+            aria-hidden="true"
+          />
+          <span
+            aria-hidden="true"
+          />
+          <span
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+      <div
+        className="navbar-menu "
+        id="navbar-burger-menu"
+      >
+        <div
+          className="navbar-end"
+        >
+          <div
+            className="navbar-item"
           >
-            <p
-              className="has-text-black"
+            <div
+              className="buttons"
             >
-              猫ちゃん画像をアップロード
-            </p>
-          </a>
-          <button
-            className="button is-outlined"
-            onClick={[Function]}
-            style={
-              Object {
-                "margin": "0.5rem 0.75rem",
-              }
-            }
-            type="submit"
-          >
-            他の猫ちゃんを表示
-          </button>
+              <a
+                className="navbar-item button"
+                href="https://github.com/nekochans/lgtm-cat-frontend"
+                style={
+                  Object {
+                    "margin": "0.5rem 0.75rem",
+                  }
+                }
+              >
+                <p
+                  className="has-text-black"
+                >
+                  猫ちゃん画像をアップロード
+                </p>
+              </a>
+              <button
+                className="button is-outlined"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "margin": "0.5rem 0.75rem",
+                  }
+                }
+                type="submit"
+              >
+                他の猫ちゃんを表示
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <p

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -13,6 +13,16 @@ const props = {
       <p className="is-size-4 has-text-black">LGTMeow</p>
     </a>
   ),
+  uploadLink: (
+    <a
+      className="navbar-item button"
+      href="https://github.com/nekochans/lgtm-cat-frontend"
+    >
+      <p className="has-text-black">猫ちゃん画像をアップロード</p>
+    </a>
+  ),
 };
 
-export const showHeader = (): JSX.Element => <Header topLink={props.topLink} />;
+export const showHeader = (): JSX.Element => (
+  <Header topLink={props.topLink} uploadLink={props.uploadLink} />
+);

--- a/src/components/Header.stories.tsx
+++ b/src/components/Header.stories.tsx
@@ -16,6 +16,7 @@ const props = {
   uploadLink: (
     <a
       className="navbar-item button"
+      style={{ margin: '0.5rem 0.75rem' }}
       href="https://github.com/nekochans/lgtm-cat-frontend"
     >
       <p className="has-text-black">猫ちゃん画像をアップロード</p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,36 +6,72 @@ type Props = {
   uploadLink: ReactNode;
 };
 
-const Header: React.FC<Props> = ({ topLink, uploadLink }: Props) => (
-  <header>
-    <nav className="navbar navbar-padding">
-      <div className="container" style={{ display: 'block' }}>
-        <div className="navbar-brand">
-          {topLink}
+const Header: React.FC<Props> = ({ topLink, uploadLink }: Props) => {
+  const [menuIsOpened, setMenuIsOpened] = React.useState(false);
+
+  const handleClickMenu = () => {
+    setMenuIsOpened(!menuIsOpened);
+  };
+
+  return (
+    <header>
+      <nav className="navbar navbar-padding">
+        <div className="container" style={{ display: 'block' }}>
+          <div className="navbar-brand">
+            {topLink}
+            <div
+              style={{
+                alignItems: 'center',
+                display: 'flex',
+                marginLeft: 'auto',
+              }}
+            />
+            {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+            <button
+              type="button"
+              onClick={handleClickMenu}
+              role="button"
+              className={`navbar-burger burger ${
+                menuIsOpened ? 'is-active' : ''
+              }`}
+              aria-label="menu"
+              aria-expanded="false"
+              data-target="navbar-burger-menu"
+            >
+              <span aria-hidden="true" />
+              <span aria-hidden="true" />
+              <span aria-hidden="true" />
+            </button>
+          </div>
+
           <div
+            id="navbar-burger-menu"
+            className={`navbar-menu ${menuIsOpened ? 'is-active' : ''}`}
+          >
+            <div className="navbar-end">
+              <div className="navbar-item">
+                <div className="buttons">
+                  {uploadLink}
+                  <RandomButtonContainer />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p
+            className="is-size-6 header-description-margin has-text-grey"
             style={{
               alignItems: 'center',
-              display: 'flex',
-              marginLeft: 'auto',
+              padding: '0 0.75rem',
             }}
           >
-            {uploadLink}
-            <RandomButtonContainer />
-          </div>
+            猫のLGTM画像を共有出来るサービスです。画像をクリックするとGitHub
+            Markdownがコピーされます。
+          </p>
         </div>
-        <p
-          className="is-size-6 header-description-margin has-text-grey"
-          style={{
-            alignItems: 'center',
-            padding: '0 0.75rem',
-          }}
-        >
-          猫のLGTM画像を共有出来るサービスです。画像をクリックするとGitHub
-          Markdownがコピーされます。
-        </p>
-      </div>
-    </nav>
-  </header>
-);
+      </nav>
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,9 +3,10 @@ import RandomButtonContainer from '../containers/RandomButton';
 
 type Props = {
   topLink: ReactNode;
+  uploadLink: ReactNode;
 };
 
-const Header: React.FC<Props> = ({ topLink }: Props) => (
+const Header: React.FC<Props> = ({ topLink, uploadLink }: Props) => (
   <header>
     <nav className="navbar navbar-padding">
       <div className="container" style={{ display: 'block' }}>
@@ -18,6 +19,7 @@ const Header: React.FC<Props> = ({ topLink }: Props) => (
               marginLeft: 'auto',
             }}
           >
+            {uploadLink}
             <RandomButtonContainer />
           </div>
         </div>

--- a/src/constants/metaTag.ts
+++ b/src/constants/metaTag.ts
@@ -32,6 +32,12 @@ export const metaTagList = (): MetaTagList => ({
     appName,
     description: defaultDescription,
   },
+  upload: {
+    title: `${defaultTitle} 猫ちゃん画像アップロード`,
+    ogpImgUrl: urlList.ogpImg,
+    ogpTargetUrl: urlList.top,
+    appName,
+  },
   terms: {
     title: `${defaultTitle} 利用規約`,
     ogpImgUrl: urlList.ogpImg,

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -4,6 +4,7 @@ export const appBaseUrl = (): string =>
 export const urlList = {
   top: appBaseUrl(),
   ogpImg: `${appBaseUrl()}/ogp.webp`,
+  upload: `${appBaseUrl()}/upload`,
   terms: `${appBaseUrl()}/terms`,
   privacy: `${appBaseUrl()}/privacy`,
 } as const;
@@ -12,9 +13,10 @@ export const apiList = { fetchLgtmImages: '/api/lgtm/images' };
 
 export const pathList = {
   top: '/',
+  upload: '/upload',
   terms: '/terms',
   privacy: '/privacy',
   error: '/error',
 } as const;
 
-export type AppPathName = 'top' | 'terms' | 'privacy';
+export type AppPathName = 'top' | 'upload' | 'terms' | 'privacy';

--- a/src/infrastructures/utils/__test__/generateSitemapXml.spec.ts
+++ b/src/infrastructures/utils/__test__/generateSitemapXml.spec.ts
@@ -9,6 +9,10 @@ describe('generateSitemapXml.ts Functions TestCases', () => {
       <changefreq>weekly</changefreq>
     </url>
     <url>
+      <loc>https://lgtmeow.com/upload/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
       <loc>https://lgtmeow.com/terms/</loc>
       <changefreq>monthly</changefreq>
     </url>

--- a/src/infrastructures/utils/generateSitemapXml.ts
+++ b/src/infrastructures/utils/generateSitemapXml.ts
@@ -8,6 +8,10 @@ const generateSitemapXml = (): string => {
       <changefreq>weekly</changefreq>
     </url>
     <url>
+      <loc>https://lgtmeow.com/upload/</loc>
+      <changefreq>weekly</changefreq>
+    </url>
+    <url>
       <loc>https://lgtmeow.com/terms/</loc>
       <changefreq>monthly</changefreq>
     </url>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -36,7 +36,7 @@ const DefaultLayout: React.FC<Props> = ({ children, metaTag }: Props) => (
       uploadLink={
         <Link href={pathList.upload}>
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a className="navbar-item button">
+          <a className="button" style={{ margin: '0.5rem 0.75rem' }}>
             <p className="has-text-black">猫ちゃん画像をアップロード</p>
           </a>
         </Link>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -33,6 +33,14 @@ const DefaultLayout: React.FC<Props> = ({ children, metaTag }: Props) => (
           </a>
         </Link>
       }
+      uploadLink={
+        <Link href={pathList.upload}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a className="navbar-item button">
+            <p className="has-text-black">猫ちゃん画像をアップロード</p>
+          </a>
+        </Link>
+      }
     />
     {children}
     <Footer

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -37,7 +37,7 @@ const DefaultLayout: React.FC<Props> = ({ children, metaTag }: Props) => (
         <Link href={pathList.upload}>
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
           <a className="button" style={{ margin: '0.5rem 0.75rem' }}>
-            <p className="has-text-black">猫ちゃん画像をアップロード</p>
+            <p className="has-text-gray">猫ちゃん画像をアップロード</p>
           </a>
         </Link>
       }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/94

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue94add-uploa-763fbb-nekochans.vercel.app/

# Done の定義

- トップページからアップロードページへのリンクが追加されている事

# スクリーンショット

あまり良くないと言われているが、ハンバーガーメニューを採用した。

理由としてはスマホで見るとButtonがはみ出してしまい、レイアウトが崩れてしまうから（PCメインのサービスだがさすがにデザイン崩れは避けたい）

## PC上での表示

![pc](https://user-images.githubusercontent.com/11032365/127080898-2e26e13f-8367-4a41-bf03-005183ef80aa.png)

## スマホ上での表示

![pc](https://user-images.githubusercontent.com/11032365/127080970-e5bcd0bc-2150-4da9-81e5-fbdf3fe673d2.png)

### ハンバーガーメニューが閉じている状態

![sp-close](https://user-images.githubusercontent.com/11032365/127080999-1a3bd082-c701-419b-8e97-6df9b560146f.png)

### ハンバーガーメニューが開いている状態

![sp-open](https://user-images.githubusercontent.com/11032365/127081020-c825f3f3-73d2-4462-9116-942fe2ab16b5.png)

# 変更点概要

headerにトップページへのリンクを追加。

リンクだが、他に合わせてButton風のデザインとした。

また、本件の趣旨とは若干ズレるが、URLの定数やsitemap、Metatagなどの追加もこのPRで行っている。

# レビュアーに重点的にチェックして欲しい点
デザインの方針が問題ないか確認してもらえると:pray:

# 補足情報
ハンバーガーメニューを開いた時に 「猫のLGTM画像を共有出来るサービスです。画像をクリックするとGitHub Markdownがコピーされます。」の部分に影がかかってしまうが、PCメインのサービスなので、一旦スルーしている。。。

https://github.com/nekochans/lgtm-cat/issues/10 の際にデザインを全面的に見直すので、ここで根本解決したい。（そもそもハンバーガーメニューを辞めたい）