### PR TITLE
画像アップロードAPIでエラーが発生した際のエラーハンドリングを追加

### DIFF
--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -1,6 +1,164 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Auth Error Cat Image Upload Form 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
 exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Success Cat Image Upload Form 1`] = `
 <div
   className="container"
 >

--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -158,6 +158,322 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
 </div>
 `;
 
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form With Auth Error 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form With Image Size Too Large Error 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form With Unexpected Error 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
+exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form With Validation Error 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="content"
+  >
+    <h1>
+      猫ちゃん画像をアップロード
+    </h1>
+    <p>
+      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
+    </p>
+    <ol>
+      <li>
+        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
+      </li>
+      <li>
+        猫が写っていない画像はアップロード出来ません。
+      </li>
+      <li>
+        人の顔がはっきり写っている画像はアップロード出来ません。
+      </li>
+      <li>
+        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
+      </li>
+    </ol>
+  </div>
+  <form
+    method="post"
+    onSubmit={[Function]}
+  >
+    <div
+      className="file has-name is-boxed"
+    >
+      <label
+        className="file-label mb-3"
+        htmlFor="cat-image-upload"
+      >
+        <input
+          className="file-input"
+          id="cat-image-upload"
+          name="uploadedCatImage"
+          onChange={[Function]}
+          type="file"
+        />
+        <span
+          className="file-cta"
+        >
+          <span
+            className="file-icon"
+          >
+            <i
+              className="fas fa-upload"
+            />
+          </span>
+          <span
+            className="file-label"
+          >
+            猫ちゃん画像を選択
+          </span>
+        </span>
+      </label>
+    </div>
+    <button
+      className="button is-primary m-4"
+      disabled={true}
+      type="submit"
+    >
+      アップロードする
+    </button>
+  </form>
+  
+  
+  
+  
+</div>
+`;
+
 exports[`Storyshots src/components/CatImageUploadForm.tsx Show Success Cat Image Upload Form 1`] = `
 <div
   className="container"

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -7,13 +7,19 @@ import {
 } from '../domain/repositories/repositoryResult';
 import { UploadedImage } from '../domain/types/image';
 import UploadCatImageAuthError from '../domain/errors/UploadCatImageAuthError';
+import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSizeTooLargeError';
+import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';
+import UploadCatImageUnexpectedError from '../domain/errors/UploadCatImageUnexpectedError';
 
 export default {
   title: 'src/components/CatImageUploadForm.tsx',
   component: Error,
   includeStories: [
-    'showSuccessCatImageUploadForm',
-    'showAuthErrorCatImageUploadForm',
+    'showCatImageUploadForm',
+    'showCatImageUploadFormWithAuthError',
+    'showCatImageUploadFormWithImageSizeTooLargeError',
+    'showCatImageUploadFormWithValidationError',
+    'showCatImageUploadFormWithUnexpectedError',
   ],
 };
 
@@ -31,10 +37,44 @@ const mockUploadCatImageAuthError: UploadCatImage = (_request) =>
     createFailureResult<UploadCatImageAuthError>(new UploadCatImageAuthError()),
   );
 
-export const showSuccessCatImageUploadForm = (): JSX.Element => (
+const mockUploadCatImageSizeTooLargeError: UploadCatImage = (_request) =>
+  Promise.resolve(
+    createFailureResult<UploadCatImageSizeTooLargeError>(
+      new UploadCatImageSizeTooLargeError(),
+    ),
+  );
+
+const mockUploadCatImageValidationError: UploadCatImage = (_request) =>
+  Promise.resolve(
+    createFailureResult<UploadCatImageValidationError>(
+      new UploadCatImageValidationError(),
+    ),
+  );
+
+const mockUploadCatImageUnexpectedError: UploadCatImage = (_request) =>
+  Promise.resolve(
+    createFailureResult<UploadCatImageUnexpectedError>(
+      new UploadCatImageUnexpectedError(),
+    ),
+  );
+
+export const showCatImageUploadForm = (): JSX.Element => (
   <CatImageUploadForm uploadCatImage={mockSuccessUploadCatImage} />
 );
 
-export const showAuthErrorCatImageUploadForm = (): JSX.Element => (
+export const showCatImageUploadFormWithAuthError = (): JSX.Element => (
   <CatImageUploadForm uploadCatImage={mockUploadCatImageAuthError} />
+);
+
+export const showCatImageUploadFormWithImageSizeTooLargeError =
+  (): JSX.Element => (
+    <CatImageUploadForm uploadCatImage={mockUploadCatImageSizeTooLargeError} />
+  );
+
+export const showCatImageUploadFormWithValidationError = (): JSX.Element => (
+  <CatImageUploadForm uploadCatImage={mockUploadCatImageValidationError} />
+);
+
+export const showCatImageUploadFormWithUnexpectedError = (): JSX.Element => (
+  <CatImageUploadForm uploadCatImage={mockUploadCatImageUnexpectedError} />
 );

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import CatImageUploadForm from './CatImageUploadForm';
 import { UploadCatImage } from '../domain/repositories/imageRepository';
-import { createSuccessResult } from '../domain/repositories/repositoryResult';
+import {
+  createFailureResult,
+  createSuccessResult,
+} from '../domain/repositories/repositoryResult';
 import { UploadedImage } from '../domain/types/image';
+import UploadCatImageAuthError from '../domain/errors/UploadCatImageAuthError';
 
 export default {
   title: 'src/components/CatImageUploadForm.tsx',
   component: Error,
-  includeStories: ['showSuccessCatImageUploadForm'],
+  includeStories: [
+    'showSuccessCatImageUploadForm',
+    'showAuthErrorCatImageUploadForm',
+  ],
 };
 
 const mockSuccessUploadCatImage: UploadCatImage = (_request) => {
@@ -19,6 +26,15 @@ const mockSuccessUploadCatImage: UploadCatImage = (_request) => {
   return Promise.resolve(createSuccessResult<UploadedImage>(uploadedImage));
 };
 
+const mockUploadCatImageAuthError: UploadCatImage = (_request) =>
+  Promise.resolve(
+    createFailureResult<UploadCatImageAuthError>(new UploadCatImageAuthError()),
+  );
+
 export const showSuccessCatImageUploadForm = (): JSX.Element => (
   <CatImageUploadForm uploadCatImage={mockSuccessUploadCatImage} />
+);
+
+export const showAuthErrorCatImageUploadForm = (): JSX.Element => (
+  <CatImageUploadForm uploadCatImage={mockUploadCatImageAuthError} />
 );

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import CatImageUploadForm from './CatImageUploadForm';
 import { UploadCatImage } from '../domain/repositories/imageRepository';
+import { createSuccessResult } from '../domain/repositories/repositoryResult';
+import { UploadedImage } from '../domain/types/image';
 
 export default {
   title: 'src/components/CatImageUploadForm.tsx',
   component: Error,
-  includeStories: ['showCatImageUploadForm'],
+  includeStories: ['showSuccessCatImageUploadForm'],
 };
 
-const mockUploadCatImage: UploadCatImage = (_request) =>
-  Promise.resolve({
+const mockSuccessUploadCatImage: UploadCatImage = (_request) => {
+  const uploadedImage = {
     imageUrl:
       'https://lgtm-images.lgtmeow.com/2021/03/16/00/35afef75-2d6d-4ca1-ab00-fb37f8848fca.webp',
-  });
+  };
 
-export const showCatImageUploadForm = (): JSX.Element => (
-  <CatImageUploadForm uploadCatImage={mockUploadCatImage} />
+  return Promise.resolve(createSuccessResult<UploadedImage>(uploadedImage));
+};
+
+export const showSuccessCatImageUploadForm = (): JSX.Element => (
+  <CatImageUploadForm uploadCatImage={mockSuccessUploadCatImage} />
 );

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -88,7 +88,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       case 'UploadCatImageValidationError':
         return '画像フォーマットが不正です。お手数ですが別の画像を利用して下さい。';
       default:
-        return 'アプロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
+        return 'アップロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
     }
   };
 

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -8,6 +8,7 @@ import {
   AcceptedTypesImageExtension,
   UploadCatImage,
 } from '../domain/repositories/imageRepository';
+import { isSuccessResult } from '../domain/repositories/repositoryResult';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -77,6 +78,17 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     }
   };
 
+  const createDisplayErrorMessage = (error: Error) => {
+    const errorName = error.name;
+
+    switch (errorName) {
+      case 'UploadCatImageAuthError':
+        return 'アプロード中に予期せぬエラーが発生しました。しばらく時間が経ってからお試し下さい。';
+      default:
+        return 'アプロード中に予期せぬエラーが発生しました。しばらく時間が経ってからお試し下さい。';
+    }
+  };
+
   const handleOnSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // TODO 以下の課題で window.confirm の利用はやめてちゃんとしたモーダルを使った処理に変更する
@@ -84,16 +96,20 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     if (window.confirm('この画像をアップロードします。よろしいですか？')) {
       // TODO アップロードAPIのエラーが発生した際の処理を追加
       // TODO アップロード中はローディング用のComponentを表示させる
-      const responseBody = await uploadCatImage({
+      const uploadCatResult = await uploadCatImage({
         image: base64Image,
         imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
       });
 
-      setUploaded(true);
-      setErrorMessage('');
-
-      if (responseBody?.imageUrl) {
-        setCreatedLgtmImageUrl(responseBody?.imageUrl);
+      if (isSuccessResult(uploadCatResult)) {
+        setUploaded(true);
+        setErrorMessage('');
+        setCreatedLgtmImageUrl(uploadCatResult.value.imageUrl);
+      } else {
+        setErrorMessage(createDisplayErrorMessage(uploadCatResult.value));
+        setImagePreviewUrl('');
+        setUploadImageExtension('');
+        setCreatedLgtmImageUrl('');
       }
 
       return true;

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -81,11 +81,14 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   const createDisplayErrorMessage = (error: Error) => {
     const errorName = error.name;
 
+    // TODO errorNameを型安全に取り出せるようにリファクタリングする
     switch (errorName) {
-      case 'UploadCatImageAuthError':
-        return 'アプロード中に予期せぬエラーが発生しました。しばらく時間が経ってからお試し下さい。';
+      case 'UploadCatImageSizeTooLargeError':
+        return '画像サイズが大きすぎます。お手数ですが2MB以下の画像を利用して下さい。';
+      case 'UploadCatImageValidationError':
+        return '画像フォーマットが不正です。お手数ですが別の画像を利用して下さい。';
       default:
-        return 'アプロード中に予期せぬエラーが発生しました。しばらく時間が経ってからお試し下さい。';
+        return 'アプロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
     }
   };
 
@@ -94,7 +97,6 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     // TODO 以下の課題で window.confirm の利用はやめてちゃんとしたモーダルを使った処理に変更する
     // https://github.com/nekochans/lgtm-cat-frontend/issues/93
     if (window.confirm('この画像をアップロードします。よろしいですか？')) {
-      // TODO アップロードAPIのエラーが発生した際の処理を追加
       // TODO アップロード中はローディング用のComponentを表示させる
       const uploadCatResult = await uploadCatImage({
         image: base64Image,

--- a/src/domain/errors/IssueAccessTokenError.ts
+++ b/src/domain/errors/IssueAccessTokenError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class IssueAccessTokenError extends ExtensibleCustomError {}

--- a/src/domain/errors/UploadCatImageAuthError.ts
+++ b/src/domain/errors/UploadCatImageAuthError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class UploadCatImageAuthError extends ExtensibleCustomError {}

--- a/src/domain/errors/UploadCatImageSizeTooLargeError.ts
+++ b/src/domain/errors/UploadCatImageSizeTooLargeError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class UploadCatImageSizeTooLargeError extends ExtensibleCustomError {}

--- a/src/domain/errors/UploadCatImageUnexpectedError.ts
+++ b/src/domain/errors/UploadCatImageUnexpectedError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class UploadCatImageUnexpectedError extends ExtensibleCustomError {}

--- a/src/domain/errors/UploadCatImageValidationError.ts
+++ b/src/domain/errors/UploadCatImageValidationError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class UploadCatImageValidationError extends ExtensibleCustomError {}

--- a/src/domain/repositories/authTokenRepository.ts
+++ b/src/domain/repositories/authTokenRepository.ts
@@ -1,3 +1,7 @@
 import { AccessToken } from '../types/authToken';
+import IssueAccessTokenError from '../errors/IssueAccessTokenError';
+import { RepositoryResult } from './repositoryResult';
 
-export type IssueAccessToken = () => Promise<AccessToken>;
+export type IssueAccessToken = () => Promise<
+  RepositoryResult<AccessToken, IssueAccessTokenError>
+>;

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,4 +1,6 @@
 import { ImageList, UploadedImage } from '../types/image';
+import { RepositoryResult } from './repositoryResult';
+import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 
 export type FetchRandomImageList = () => Promise<ImageList>;
 
@@ -11,4 +13,4 @@ export type UploadCatImageRequest = {
 
 export type UploadCatImage = (
   request: UploadCatImageRequest,
-) => Promise<UploadedImage>;
+) => Promise<RepositoryResult<UploadedImage, UploadCatImageAuthError | Error>>;

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,6 +1,9 @@
 import { ImageList, UploadedImage } from '../types/image';
 import { RepositoryResult } from './repositoryResult';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
+import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
+import UploadCatImageValidationError from '../errors/UploadCatImageValidationError';
+import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
 
 export type FetchRandomImageList = () => Promise<ImageList>;
 
@@ -13,4 +16,12 @@ export type UploadCatImageRequest = {
 
 export type UploadCatImage = (
   request: UploadCatImageRequest,
-) => Promise<RepositoryResult<UploadedImage, UploadCatImageAuthError | Error>>;
+) => Promise<
+  RepositoryResult<
+    UploadedImage,
+    | UploadCatImageAuthError
+    | UploadCatImageSizeTooLargeError
+    | UploadCatImageValidationError
+    | UploadCatImageUnexpectedError
+  >
+>;

--- a/src/domain/repositories/repositoryResult.ts
+++ b/src/domain/repositories/repositoryResult.ts
@@ -1,0 +1,26 @@
+export const SuccessMarker = 'SuccessMarker';
+export const FailureMarker = 'FailureMarker';
+
+export type SuccessResult<T> = { value: T; _: typeof SuccessMarker };
+export type FailureResult<E> = { value: E; _: typeof FailureMarker };
+export type RepositoryResult<T, E> = SuccessResult<T> | FailureResult<E>;
+
+export const createSuccessResult = <T>(value: T): SuccessResult<T> => ({
+  value,
+  _: SuccessMarker,
+});
+
+export const createFailureResult = <E>(value: E): FailureResult<E> => ({
+  value,
+  _: FailureMarker,
+});
+
+export const isSuccessResult = <T>(
+  result: RepositoryResult<unknown, unknown>,
+): result is SuccessResult<T> => {
+  if ('_' in result) {
+    return result._ === SuccessMarker;
+  }
+
+  return false;
+};

--- a/src/infrastructures/repositories/api/fetch/__test__/authTokenRepository/issueAccessToken.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__test__/authTokenRepository/issueAccessToken.spec.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import fetch from 'jest-fetch-mock';
 import { issueAccessToken } from '../../authTokenRepository';
+import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
 
 describe('authTokenRepository.ts issueAccessToken TestCases', () => {
   beforeEach(() => {
@@ -22,13 +23,14 @@ describe('authTokenRepository.ts issueAccessToken TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const accessToken = await issueAccessToken();
+    const accessTokenResult = await issueAccessToken();
 
-    const expected = {
+    const expectedValue = {
       jwtString: mockBody.access_token,
     };
 
-    expect(accessToken).toStrictEqual(expected);
+    expect(isSuccessResult(accessTokenResult)).toBeTruthy();
+    expect(accessTokenResult.value).toStrictEqual(expectedValue);
   });
 
   // TODO 異常系のテストケースを実装する

--- a/src/infrastructures/repositories/api/fetch/__test__/imageRepository/uploadCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__test__/imageRepository/uploadCatImage.spec.ts
@@ -2,6 +2,7 @@
 import fetch from 'jest-fetch-mock';
 import { uploadCatImage } from '../../imageRepository';
 import { UploadCatImageRequest } from '../../../../../../domain/repositories/imageRepository';
+import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
 
 describe('imageRepository.ts uploadCatImage TestCases', () => {
   beforeEach(() => {
@@ -26,9 +27,10 @@ describe('imageRepository.ts uploadCatImage TestCases', () => {
       imageExtension: '.jpg',
     };
 
-    const uploadedImage = await uploadCatImage(request);
+    const uploadedImageResult = await uploadCatImage(request);
 
-    expect(uploadedImage).toStrictEqual(mockBody);
+    expect(isSuccessResult(uploadedImageResult)).toBeTruthy();
+    expect(uploadedImageResult.value).toStrictEqual(mockBody);
   });
 
   // TODO 異常系のテストケースを実装

--- a/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
@@ -4,6 +4,12 @@ import {
   cognitoClientId,
   cognitoClientSecret,
 } from '../../../../constants/secret';
+import IssueAccessTokenError from '../../../../domain/errors/IssueAccessTokenError';
+import {
+  createFailureResult,
+  createSuccessResult,
+} from '../../../../domain/repositories/repositoryResult';
+import { AccessToken } from '../../../../domain/types/authToken';
 
 type CognitoTokenResponseBody = {
   // eslint-disable-next-line camelcase
@@ -16,23 +22,38 @@ type CognitoTokenResponseBody = {
 
 // eslint-disable-next-line import/prefer-default-export
 export const issueAccessToken: IssueAccessToken = async () => {
-  const authorization = Buffer.from(
-    `${cognitoClientId()}:${cognitoClientSecret()}`,
-  ).toString('base64');
+  try {
+    const authorization = Buffer.from(
+      `${cognitoClientId()}:${cognitoClientSecret()}`,
+    ).toString('base64');
 
-  const options = {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      Authorization: `Basic ${authorization}`,
-    },
-    body: 'grant_type=client_credentials&scope=api.lgtmeow/all',
-  };
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${authorization}`,
+      },
+      body: 'grant_type=client_credentials&scope=api.lgtmeow/all',
+    };
 
-  const response = await fetch(cognitoTokenEndpointUrl(), options);
+    const response = await fetch(cognitoTokenEndpointUrl(), options);
 
-  const cognitoTokenResponseBody =
-    (await response.json()) as CognitoTokenResponseBody;
+    const cognitoTokenResponseBody =
+      (await response.json()) as CognitoTokenResponseBody;
 
-  return { jwtString: cognitoTokenResponseBody.access_token };
+    if (response.status !== 200 || !cognitoTokenResponseBody.access_token) {
+      return createFailureResult<IssueAccessTokenError>(
+        new IssueAccessTokenError(),
+      );
+    }
+
+    return createSuccessResult<AccessToken>({
+      jwtString: cognitoTokenResponseBody.access_token,
+    });
+  } catch (error) {
+    // TODO このブロックに入った時は原因不明なエラーなのでSlack等に通知を送信したい
+    const newError = new IssueAccessTokenError(error);
+
+    return createFailureResult<IssueAccessTokenError>(newError);
+  }
 };

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -5,6 +5,12 @@ import {
 } from '../../../../domain/repositories/imageRepository';
 import FetchRandomImageListError from '../../../../domain/errors/FetchRandomImageListError';
 import { apiList } from '../../../../constants/url';
+import { UploadedImageResponse } from '../../../../pages/api/lgtm/images';
+import {
+  createFailureResult,
+  createSuccessResult,
+} from '../../../../domain/repositories/repositoryResult';
+import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
 
 export const fetchRandomImageList: FetchRandomImageList = async () => {
   const response = await fetch(apiList.fetchLgtmImages);
@@ -30,7 +36,25 @@ export const uploadCatImage: UploadCatImage = async (request) => {
 
   const response = await fetch(apiList.uploadCatImage, options);
 
+  if (response.status !== 202) {
+    const errorBody = (await response.json()) as UploadedImageResponse;
+
+    switch (errorBody.error?.message) {
+      case 'IssueAccessTokenError':
+        return createFailureResult<UploadCatImageAuthError>(
+          new UploadCatImageAuthError(),
+        );
+      default:
+        // TODO 後で例外的なエラーを定義する
+        return createFailureResult<UploadCatImageAuthError>(
+          new UploadCatImageAuthError(),
+        );
+    }
+  }
+
   // TODO response.status が 202 以外はエラーを返す
 
-  return (await response.json()) as UploadedImage;
+  const uploadedImage = (await response.json()) as UploadedImage;
+
+  return createSuccessResult<UploadedImage>(uploadedImage);
 };

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -11,6 +11,9 @@ import {
   createSuccessResult,
 } from '../../../../domain/repositories/repositoryResult';
 import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
+import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
+import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
+import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
 
 export const fetchRandomImageList: FetchRandomImageList = async () => {
   const response = await fetch(apiList.fetchLgtmImages);
@@ -39,20 +42,26 @@ export const uploadCatImage: UploadCatImage = async (request) => {
   if (response.status !== 202) {
     const errorBody = (await response.json()) as UploadedImageResponse;
 
+    // TODO メッセージを型安全に取り出せるようにリファクタリングする
     switch (errorBody.error?.message) {
       case 'IssueAccessTokenError':
         return createFailureResult<UploadCatImageAuthError>(
           new UploadCatImageAuthError(),
         );
+      case 'UploadCatImageSizeTooLargeError':
+        return createFailureResult<UploadCatImageSizeTooLargeError>(
+          new UploadCatImageSizeTooLargeError(),
+        );
+      case 'UploadCatImageValidationError':
+        return createFailureResult<UploadCatImageValidationError>(
+          new UploadCatImageValidationError(),
+        );
       default:
-        // TODO 後で例外的なエラーを定義する
-        return createFailureResult<UploadCatImageAuthError>(
-          new UploadCatImageAuthError(),
+        return createFailureResult<UploadCatImageUnexpectedError>(
+          new UploadCatImageUnexpectedError(),
         );
     }
   }
-
-  // TODO response.status が 202 以外はエラーを返す
 
   const uploadedImage = (await response.json()) as UploadedImage;
 

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -40,6 +40,14 @@ export const uploadCatImage: UploadCatImage = async (request) => {
   const response = await fetch(apiList.uploadCatImage, options);
 
   if (response.status !== 202) {
+    // vercelのpayloadサイズリミットに引っかかった場合
+    // https://vercel.com/docs/platform/limits#serverless-function-payload-size-limit
+    if (response.status !== 413) {
+      return createFailureResult<UploadCatImageSizeTooLargeError>(
+        new UploadCatImageSizeTooLargeError(),
+      );
+    }
+
     const errorBody = (await response.json()) as UploadedImageResponse;
 
     // TODO メッセージを型安全に取り出せるようにリファクタリングする

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -69,8 +69,6 @@ const uploadCatImage = async (
 ) => {
   const requestBody = req.body as UploadCatImageRequest;
 
-  console.log(requestBody);
-
   const accessTokenResult = await issueAccessToken();
 
   if (isSuccessResult(accessTokenResult)) {

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -69,6 +69,8 @@ const uploadCatImage = async (
 ) => {
   const requestBody = req.body as UploadCatImageRequest;
 
+  console.log(requestBody);
+
   const accessTokenResult = await issueAccessToken();
 
   if (isSuccessResult(accessTokenResult)) {
@@ -124,7 +126,7 @@ const handler: NextApiHandler = async (
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '5mb',
+      sizeLimit: '10mb',
     },
   },
 };

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -124,7 +124,7 @@ const handler: NextApiHandler = async (
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: '10mb',
+      sizeLimit: '5mb',
     },
   },
 };


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/76

https://github.com/nekochans/lgtm-cat-frontend/pull/104 のPRに依存している。

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue76add-error-6d4bbb-nekochans.vercel.app/upload

# Done の定義

- 画像アップロードAPIからエラーが返ってきた場合、適切なエラーメッセージが表示されるようになっている事

# スクリーンショット

## 画像ファイルのサイズが大きすぎてAPI Gatewayから413が返ってきた場合の表示

![ImageSizeTooLargeError](https://user-images.githubusercontent.com/11032365/129300860-addd2425-1af1-4597-b8f5-2c8d2f2bd182.png)

## 画像ファイルのフォーマットが拡張子が許可されていない物だった場合の表示（フォーム側でチェックしているので、基本は起きないハズ）

![ValidationError](https://user-images.githubusercontent.com/11032365/129300851-93c380d5-65c5-45f1-9c79-3e94fd2b6d11.png)

## それ以外のエラーの場合（アクセストークン発行時にエラーになった場合も含む）

![UnexpectedError](https://user-images.githubusercontent.com/11032365/129300948-a7223d55-c3c7-471f-9e5b-2300c89a3c32.png)

# 変更点概要

- Repositoryから適切なエラーを返すように変更
- Repositoryから返ってきたエラーを元に適切なエラーメッセージを表示させるように変更（詳細はスクリーンショットを参照）

# レビュアーに重点的にチェックして欲しい点

https://github.com/nekochans/lgtm-cat-api/blob/main/main.go を見ながら返ってくるエラーを確認してハンドリングが必要な物を設定しているから、エラーメッセージと合わせて問題ないか確認してもらえると:pray:

基本的に `422` と `413` が返ってきた時だけ、特別なエラーメッセージにすれば良いかなと思っているよ:cat2:

## ギリギリアップロードが可能な画像（容量2.3MB）

![linli-xu-C26VKA9BMYQ-unsplash](https://user-images.githubusercontent.com/11032365/129297655-d571a0cb-642f-42e8-ae13-3ad62c8700cc.jpg)

↓のように無事にLGTM画像を生成出来た🐱

[![LGTMeow](https://stg-lgtm-images.lgtmeow.com/2021/08/13/11/1b2cf7cc-999b-4d93-8236-f00c7d17359d.webp)](http://localhost:2222)

## アップロード不可能な画像（容量5.6MB）

API Gatewayの制限に引っかかって、 `HTTP 413 { message: 'Request Entity Too Large' }` が返ってくる:cat2:

![MokoCatBig](https://user-images.githubusercontent.com/11032365/129297751-34539378-78e4-46d2-bf7f-23595d5d1f8b.png)

ローカルだと再現出来るけど、Vercelのプレビュー環境だとVercelからエラーが返ってくるので、再現出来ないので、これは別PRで対応予定:sweat_drops:

# 補足情報
画像解析でエラーが起きるとトレースが結構大変なので https://github.com/nekochans/lgtm-cat-image-recognition/issues/26 でエラーログを出すように修正する予定。
