### PR TITLE
画像アップロードAPIへ通信中にProgressBarを表示されるように変更

### DIFF
--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -1,84 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots src/components/CatImageUploadForm.tsx Show Auth Error Cat Image Upload Form 1`] = `
-<div
-  className="container"
->
-  <div
-    className="content"
-  >
-    <h1>
-      猫ちゃん画像をアップロード
-    </h1>
-    <p>
-      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
-    </p>
-    <ol>
-      <li>
-        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
-      </li>
-      <li>
-        猫が写っていない画像はアップロード出来ません。
-      </li>
-      <li>
-        人の顔がはっきり写っている画像はアップロード出来ません。
-      </li>
-      <li>
-        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
-      </li>
-    </ol>
-  </div>
-  <form
-    method="post"
-    onSubmit={[Function]}
-  >
-    <div
-      className="file has-name is-boxed"
-    >
-      <label
-        className="file-label mb-3"
-        htmlFor="cat-image-upload"
-      >
-        <input
-          className="file-input"
-          id="cat-image-upload"
-          name="uploadedCatImage"
-          onChange={[Function]}
-          type="file"
-        />
-        <span
-          className="file-cta"
-        >
-          <span
-            className="file-icon"
-          >
-            <i
-              className="fas fa-upload"
-            />
-          </span>
-          <span
-            className="file-label"
-          >
-            猫ちゃん画像を選択
-          </span>
-        </span>
-      </label>
-    </div>
-    <button
-      className="button is-primary m-4"
-      disabled={true}
-      type="submit"
-    >
-      アップロードする
-    </button>
-  </form>
-  
-  
-  
-  
-</div>
-`;
-
 exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload Form 1`] = `
 <div
   className="container"
@@ -151,6 +72,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
       アップロードする
     </button>
   </form>
+  
   
   
   
@@ -234,6 +156,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
   
   
   
+  
 </div>
 `;
 
@@ -309,6 +232,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
       アップロードする
     </button>
   </form>
+  
   
   
   
@@ -392,6 +316,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
   
   
   
+  
 </div>
 `;
 
@@ -468,84 +393,6 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     </button>
   </form>
   
-  
-  
-  
-</div>
-`;
-
-exports[`Storyshots src/components/CatImageUploadForm.tsx Show Success Cat Image Upload Form 1`] = `
-<div
-  className="container"
->
-  <div
-    className="content"
-  >
-    <h1>
-      猫ちゃん画像をアップロード
-    </h1>
-    <p>
-      猫ちゃん画像をアップロードしてLGTM画像を作れます🐱 利用出来る画像には以下の制約があります。
-    </p>
-    <ol>
-      <li>
-        拡張子が png, jpg, jpeg の画像のみアップロード出来ます。
-      </li>
-      <li>
-        猫が写っていない画像はアップロード出来ません。
-      </li>
-      <li>
-        人の顔がはっきり写っている画像はアップロード出来ません。
-      </li>
-      <li>
-        猫のイラスト等の猫画像はアップロード出来ません。（そのうち出来るようにしたいです。）
-      </li>
-    </ol>
-  </div>
-  <form
-    method="post"
-    onSubmit={[Function]}
-  >
-    <div
-      className="file has-name is-boxed"
-    >
-      <label
-        className="file-label mb-3"
-        htmlFor="cat-image-upload"
-      >
-        <input
-          className="file-input"
-          id="cat-image-upload"
-          name="uploadedCatImage"
-          onChange={[Function]}
-          type="file"
-        />
-        <span
-          className="file-cta"
-        >
-          <span
-            className="file-icon"
-          >
-            <i
-              className="fas fa-upload"
-            />
-          </span>
-          <span
-            className="file-label"
-          >
-            猫ちゃん画像を選択
-          </span>
-        </span>
-      </label>
-    </div>
-    <button
-      className="button is-primary m-4"
-      disabled={true}
-      type="submit"
-    >
-      アップロードする
-    </button>
-  </form>
   
   
   

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -23,13 +23,17 @@ export default {
   ],
 };
 
-const mockSuccessUploadCatImage: UploadCatImage = (_request) => {
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const mockSuccessUploadCatImage: UploadCatImage = async (_request) => {
   const uploadedImage = {
     imageUrl:
       'https://lgtm-images.lgtmeow.com/2021/03/16/00/35afef75-2d6d-4ca1-ab00-fb37f8848fca.webp',
   };
 
-  return Promise.resolve(createSuccessResult<UploadedImage>(uploadedImage));
+  await sleep(3000);
+
+  return createSuccessResult<UploadedImage>(uploadedImage);
 };
 
 const mockUploadCatImageAuthError: UploadCatImage = (_request) =>

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -9,6 +9,7 @@ import {
   UploadCatImage,
 } from '../domain/repositories/imageRepository';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
+import ProgressBar from './ProgressBar';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -26,6 +27,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   const [createdLgtmImageUrl, setCreatedLgtmImageUrl] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState<string>();
   const [uploaded, setUploaded] = useState<boolean>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   // TODO どの画像を許可するかはビジネスロジックとして意味があるので分離する
   const isValidFileType = (fileType: string): boolean =>
@@ -62,6 +64,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
         setImagePreviewUrl('');
         setUploadImageExtension('');
         setCreatedLgtmImageUrl('');
+        setIsLoading(false);
 
         return;
       }
@@ -71,6 +74,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       setErrorMessage('');
       setImagePreviewUrl(url);
       setUploadImageExtension(extractImageExtFromValidFileType(fileType));
+      setIsLoading(false);
 
       const reader = new FileReader();
       reader.onload = handleReaderLoaded;
@@ -97,7 +101,8 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     // TODO 以下の課題で window.confirm の利用はやめてちゃんとしたモーダルを使った処理に変更する
     // https://github.com/nekochans/lgtm-cat-frontend/issues/93
     if (window.confirm('この画像をアップロードします。よろしいですか？')) {
-      // TODO アップロード中はローディング用のComponentを表示させる
+      setIsLoading(true);
+
       const uploadCatResult = await uploadCatImage({
         image: base64Image,
         imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
@@ -107,11 +112,13 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
         setUploaded(true);
         setErrorMessage('');
         setCreatedLgtmImageUrl(uploadCatResult.value.imageUrl);
+        setIsLoading(false);
       } else {
         setErrorMessage(createDisplayErrorMessage(uploadCatResult.value));
         setImagePreviewUrl('');
         setUploadImageExtension('');
         setCreatedLgtmImageUrl('');
+        setIsLoading(false);
       }
 
       return true;
@@ -164,6 +171,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
           アップロードする
         </button>
       </form>
+      {isLoading ? <ProgressBar /> : ''}
       {imagePreviewUrl && !uploaded ? (
         <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
       ) : (

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ProgressBar: React.FC = () => (
+  <>
+    <p>通信中です</p>
+    <progress className="progress is-large is-primary" max="100">
+      100%
+    </progress>
+  </>
+);
+
+export default ProgressBar;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-frontend/issues/76

他にも以下のPRに依存している↓

- https://github.com/nekochans/lgtm-cat-frontend/pull/104
- https://github.com/nekochans/lgtm-cat-frontend/pull/105

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue76add-progress-bar-nekochans.vercel.app/upload

# Done の定義

- 画像アップロード用APIへの通信中にローディング用のComponentが表示されるように変更されている事

# スクリーンショット

![progress-bar](https://user-images.githubusercontent.com/11032365/129436490-7c39e797-2af6-4b52-bcf9-9255f00e0d06.png)

# 変更点概要

以下を参考に `ProgressBar` を定義した。

https://bulma.io/documentation/elements/progress/

通信中はこれを表示されるようにしている。

汎用的な名前だが全ての場所で汎用的に利用される事は現時点では想定出来ていない。

# レビュアーに重点的にチェックして欲しい点

Component名と表示に問題にないか確認してもらえると:pray: