### PR TITLE
画像アップロードにGAにカスタムイベントを送信するように改修

### DIFF
--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '../domain/repositories/imageRepository';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import ProgressBar from './ProgressBar';
+import { sendUploadCatImage } from '../infrastructures/utils/gtag';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -120,6 +121,8 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
         setCreatedLgtmImageUrl('');
         setIsLoading(false);
       }
+
+      sendUploadCatImage('upload_cat_image_button');
 
       return true;
     }

--- a/src/components/CreatedLgtmImage.tsx
+++ b/src/components/CreatedLgtmImage.tsx
@@ -15,7 +15,7 @@ const CreatedLgtmImage: React.FC<Props> = ({
   const [opacity, setOpacity] = useState('1');
 
   const onCopySuccess = useCallback(() => {
-    sendCopyMarkdownEvent('copy_markdown_button');
+    sendCopyMarkdownEvent('created_lgtm_image');
 
     setOpacity('1');
     setCopied(true);

--- a/src/infrastructures/utils/gtag.ts
+++ b/src/infrastructures/utils/gtag.ts
@@ -55,3 +55,16 @@ export const sendFetchRandomImages = (
     value: 1,
   });
 };
+
+// ねこ画像がアップロードしLGTM画像を作成する機能が利用された際に実行する
+
+type SendUploadCatImageLabel = 'upload_cat_image_button';
+
+export const sendUploadCatImage = (label: SendUploadCatImageLabel): void => {
+  event({
+    action: 'upload_cat_image',
+    category: 'upload_cat_image',
+    label,
+    value: 1,
+  });
+};

--- a/src/infrastructures/utils/gtag.ts
+++ b/src/infrastructures/utils/gtag.ts
@@ -28,7 +28,7 @@ export const event = ({ action, category, label, value }: GaEventProps) => {
 };
 
 // Markdownソースがコピーされた際に実行する
-type SendCopyMarkdownEventLabel = 'copy_markdown_button';
+type SendCopyMarkdownEventLabel = 'copy_markdown_button' | 'created_lgtm_image';
 
 export const sendCopyMarkdownEvent = (
   label: SendCopyMarkdownEventLabel,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/109

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue109add-send-86c2d4-nekochans.vercel.app/upload

# Done の定義

- 画像アップロードが行われたタイミングでGAにカスタムイベントが送信されるようになっている事

# スクリーンショット

以下のように `upload_cat_image` が確認出来る。

![GA](https://user-images.githubusercontent.com/11032365/131522066-cac0ef56-0efc-4951-9915-d668a0a543db.png)

# 変更点概要

画像アップロードのGAイベント送信用関数 `sendUploadCatImage` を定義。

またアップロード後の画像をクリックするとMarkdownソースがコピーされるので、`sendCopyMarkdownEvent` でイベント送信する際に別のラベルを定義して区別が出来るように設定した。

https://github.com/nekochans/lgtm-cat-frontend/pull/110/commits/65ab763950cb766c12a1e2ebf0481d36320cbc2f

# レビュアーに重点的にチェックして欲しい点

イベント名とか、基本方針問題ないか確認してもらえると:pray: