### PR TITLE
アップロード後の画面にMarkdownソースコピー用のButtonを追加

### DIFF
--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -71,6 +71,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     >
       アップロードする
     </button>
+    
   </form>
   
   
@@ -151,6 +152,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     >
       アップロードする
     </button>
+    
   </form>
   
   
@@ -231,6 +233,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     >
       アップロードする
     </button>
+    
   </form>
   
   
@@ -311,6 +314,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     >
       アップロードする
     </button>
+    
   </form>
   
   
@@ -391,6 +395,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     >
       アップロードする
     </button>
+    
   </form>
   
   

--- a/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
+++ b/src/__tests__/__snapshots__/CatImageUploadForm.stories.storyshot
@@ -78,6 +78,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
   
   
   
+  
 </div>
 `;
 
@@ -154,6 +155,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     </button>
     
   </form>
+  
   
   
   
@@ -240,6 +242,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
   
   
   
+  
 </div>
 `;
 
@@ -321,6 +324,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
   
   
   
+  
 </div>
 `;
 
@@ -397,6 +401,7 @@ exports[`Storyshots src/components/CatImageUploadForm.tsx Show Cat Image Upload 
     </button>
     
   </form>
+  
   
   
   

--- a/src/components/AfterUploadWarningMessage.tsx
+++ b/src/components/AfterUploadWarningMessage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+// TODO このComponentは https://github.com/nekochans/lgtm-cat/issues/15 の開発が終了した時点で削除する
+const AfterUploadWarningMessage: React.FC = () => (
+  <article className="message is-warning">
+    <div className="message-header">
+      <p>注意 🐱！</p>
+    </div>
+    <div className="message-body">
+      <p>
+        この画面から移動するとMarkdownソースをコピー出来なくなるのでご注意下さい。
+      </p>
+    </div>
+  </article>
+);
+
+export default AfterUploadWarningMessage;

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -12,6 +12,7 @@ import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import ProgressBar from './ProgressBar';
 import { sendUploadCatImage } from '../infrastructures/utils/gtag';
 import CopyMarkdownSourceButton from './CopyMarkdownSourceButton';
+import AfterUploadWarningMessage from './AfterUploadWarningMessage';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -190,6 +191,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       )}
       {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
       {uploaded ? <CatImageUploadSuccessMessage /> : ''}
+      {uploaded ? <AfterUploadWarningMessage /> : ''}
       {uploaded ? (
         <CreatedLgtmImage
           imagePreviewUrl={createdLgtmImageProps.imagePreviewUrl}

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -11,6 +11,7 @@ import {
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import ProgressBar from './ProgressBar';
 import { sendUploadCatImage } from '../infrastructures/utils/gtag';
+import CopyMarkdownSourceButton from './CopyMarkdownSourceButton';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -173,6 +174,13 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
         >
           アップロードする
         </button>
+        {uploaded ? (
+          <CopyMarkdownSourceButton
+            createdLgtmImageUrl={createdLgtmImageProps.createdLgtmImageUrl}
+          />
+        ) : (
+          ''
+        )}
       </form>
       {isLoading ? <ProgressBar /> : ''}
       {imagePreviewUrl && !uploaded ? (

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -7,8 +7,12 @@ const CatImageUploadSuccessMessage: React.FC = () => (
     </div>
     <div className="message-body">
       <p>アップロードされた画像を審査していますので、少々お待ち下さい。</p>
-      <p>「Markdownソースをコピー」ボタンか以下の画像をクリックするとMarkdownソースがコピーされます。</p>
-      <p>審査に合格していれば、コピーされたMarkdownソースで生成されたLGTM画像を確認出来ます。</p>
+      <p>
+        「Markdownソースをコピー」ボタンか以下の画像をクリックするとMarkdownソースがコピーされます。
+      </p>
+      <p>
+        審査に合格していれば、コピーされたMarkdownソースで生成されたLGTM画像を確認出来ます。
+      </p>
     </div>
   </article>
 );

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -6,9 +6,9 @@ const CatImageUploadSuccessMessage: React.FC = () => (
       <p>アップロードに成功しました🐱！</p>
     </div>
     <div className="message-body">
-      アップロードされた画像を審査していますので、少々お待ち下さい。
-      以下の画像をクリックするとMarkdownソースがコピーされます。
-      審査に合格していれば、コピーされたMarkdownソースで生成されたLGTM画像を確認出来ます。
+      <p>アップロードされた画像を審査していますので、少々お待ち下さい。</p>
+      <p>「Markdownソースをコピー」ボタンか以下の画像をクリックするとMarkdownソースがコピーされます。</p>
+      <p>審査に合格していれば、コピーされたMarkdownソースで生成されたLGTM画像を確認出来ます。</p>
     </div>
   </article>
 );

--- a/src/components/CopyMarkdownSourceButton.tsx
+++ b/src/components/CopyMarkdownSourceButton.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useState } from 'react';
+import { sendCopyMarkdownEvent } from '../infrastructures/utils/gtag';
+import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
+
+type Props = {
+  createdLgtmImageUrl: string;
+};
+
+const CopyMarkdownSourceButton: React.FC<Props> = ({ createdLgtmImageUrl }) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopySuccess = useCallback(() => {
+    sendCopyMarkdownEvent('after_upload_copy_markdown_button');
+
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+    }, 1000);
+  }, []);
+
+  const { imageContextRef } = useClipboardMarkdown(
+    onCopySuccess,
+    createdLgtmImageUrl,
+  );
+
+  return (
+    <>
+      <button
+        className="button is-primary m-4"
+        type="button"
+        ref={imageContextRef}
+      >
+        Markdownソースをコピー
+      </button>
+      {copied && (
+        <div
+          style={{
+            position: 'absolute',
+            textAlign: 'center',
+            bottom: '25%',
+            left: '50%',
+            color: 'white',
+            transform: 'translate(-50%, 0)',
+            background: 'rgba(0, 0, 0, 0.5)',
+            borderRadius: '30px',
+            padding: '3%',
+          }}
+        >
+          Github Markdown Copied!
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CopyMarkdownSourceButton;

--- a/src/components/CopyMarkdownSourceButton.tsx
+++ b/src/components/CopyMarkdownSourceButton.tsx
@@ -37,7 +37,7 @@ const CopyMarkdownSourceButton: React.FC<Props> = ({ createdLgtmImageUrl }) => {
           style={{
             position: 'absolute',
             textAlign: 'center',
-            top: '50%',
+            top: '200px',
             left: '50%',
             color: 'white',
             transform: 'translate(-50%, 0)',

--- a/src/components/CopyMarkdownSourceButton.tsx
+++ b/src/components/CopyMarkdownSourceButton.tsx
@@ -37,7 +37,7 @@ const CopyMarkdownSourceButton: React.FC<Props> = ({ createdLgtmImageUrl }) => {
           style={{
             position: 'absolute',
             textAlign: 'center',
-            bottom: '25%',
+            top: '50%',
             left: '50%',
             color: 'white',
             transform: 'translate(-50%, 0)',

--- a/src/infrastructures/utils/gtag.ts
+++ b/src/infrastructures/utils/gtag.ts
@@ -28,7 +28,10 @@ export const event = ({ action, category, label, value }: GaEventProps) => {
 };
 
 // Markdownソースがコピーされた際に実行する
-type SendCopyMarkdownEventLabel = 'copy_markdown_button' | 'created_lgtm_image';
+type SendCopyMarkdownEventLabel =
+  | 'copy_markdown_button'
+  | 'created_lgtm_image'
+  | 'after_upload_copy_markdown_button';
 
 export const sendCopyMarkdownEvent = (
   label: SendCopyMarkdownEventLabel,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/108

https://github.com/nekochans/lgtm-cat-frontend/pull/110 のPRに依存しているので先に https://github.com/nekochans/lgtm-cat-frontend/pull/110 をマージする必要がある。

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue108add-copy-button-nekochans.vercel.app/upload

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/108 の完了の定義を満たしている事

# スクリーンショット

![image](https://user-images.githubusercontent.com/11032365/132645007-790986e6-dea4-4328-974b-971e9a33c169.png)

# 変更点概要

- 画像アップロード後にMarkdownソースをコピーするボタンを追加
- ページから移動すると現状、アップロードした画像を探し出す手段がないので注意書き用のComponentを追加

またPRの趣旨とは関係ないが、`CatImageUploadSuccessMessage` に表示されているメッセージが横に長いので、改行して表示するように変更。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

注意書きが少し大げさな気もしなくはないけど、アップロードしたのでコピーし忘れて離脱ってパターンを避けるために少々大げさにした🐱！