### PR TITLE
画像アップロード確認用のモーダルを作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-markdown": "^5.0.3",
+        "react-modal": "^3.14.4",
         "sass": "^1.39.2"
       },
       "devDependencies": {
@@ -35,6 +36,7 @@
         "@types/prettier": "^2.3.2",
         "@types/react": "^17.0.21",
         "@types/react-dom": "^17.0.9",
+        "@types/react-modal": "^3.13.1",
         "@types/stylelint": "^13.13.2",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
@@ -6667,6 +6669,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-syntax-highlighter": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
@@ -12418,6 +12429,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -24859,8 +24875,7 @@
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-markdown": {
       "version": "5.0.3",
@@ -24902,6 +24917,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-modal": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
+      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
       }
     },
     "node_modules/react-popper": {
@@ -30174,7 +30207,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -36264,6 +36296,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-modal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
+      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz",
@@ -40828,6 +40869,11 @@
       "requires": {
         "clone-regexp": "^2.1.0"
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
     },
     "exit": {
       "version": "0.1.2",
@@ -50490,8 +50536,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-markdown": {
       "version": "5.0.3",
@@ -50523,6 +50568,17 @@
             "mdast-util-from-markdown": "^0.8.0"
           }
         }
+      }
+    },
+    "react-modal": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
+      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
       }
     },
     "react-popper": {
@@ -54599,7 +54655,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^5.0.3",
+    "react-modal": "^3.14.4",
     "sass": "^1.39.2"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@types/prettier": "^2.3.2",
     "@types/react": "^17.0.21",
     "@types/react-dom": "^17.0.9",
+    "@types/react-modal": "^3.13.1",
     "@types/stylelint": "^13.13.2",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",

--- a/src/components/CatImageUploadConfirmModal.tsx
+++ b/src/components/CatImageUploadConfirmModal.tsx
@@ -15,7 +15,7 @@ const CatImageUploadConfirmModal: React.FC<Props> = ({
   onClickUpload,
   imagePreviewUrl,
 }) => (
-  <Modal isOpen={isOpen} ariaHideApp={false}>
+  <Modal isOpen={isOpen} ariaHideApp={false} onRequestClose={onClickCancel}>
     <div className="modal is-active">
       <div className="modal-background" />
       <div className="modal-card">

--- a/src/components/CatImageUploadConfirmModal.tsx
+++ b/src/components/CatImageUploadConfirmModal.tsx
@@ -6,7 +6,9 @@ type Props = {
   isOpen: boolean;
   onClickCancel: () => void;
   onClickUpload: () => Promise<void>;
-  imagePreviewUrl: string;
+  // TODO react/require-default-props のルールは無効化したほうが良いかも、Default値を持たせるにしても関数型Componentの場合は引数のDefault値で表現するべき
+  // eslint-disable-next-line react/require-default-props
+  imagePreviewUrl?: string;
 };
 
 const CatImageUploadConfirmModal: React.FC<Props> = ({
@@ -30,7 +32,11 @@ const CatImageUploadConfirmModal: React.FC<Props> = ({
         </header>
         <section className="modal-card-body">
           <strong>この画像をアップロードします。よろしいですか？</strong>
-          <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
+          {imagePreviewUrl ? (
+            <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
+          ) : (
+            ''
+          )}
         </section>
         <footer className="modal-card-foot">
           <button

--- a/src/components/CatImageUploadConfirmModal.tsx
+++ b/src/components/CatImageUploadConfirmModal.tsx
@@ -1,32 +1,52 @@
 import React from 'react';
+import Modal from 'react-modal';
 import UploadCatImagePreview from './UploadCatImagePreview';
 
 type Props = {
+  isOpen: boolean;
+  onClickCancel: () => void;
+  onClickUpload: () => Promise<void>;
   imagePreviewUrl: string;
 };
 
-const CatImageUploadConfirmModal: React.FC<Props> = ({ imagePreviewUrl }) => (
-  <div className="modal is-active">
-    <div className="modal-background" />
-    <div className="modal-card">
-      <header className="modal-card-head">
-        <p className="modal-card-title">猫ちゃん画像アップロード確認</p>
-        <button type="button" className="delete" aria-label="close" />
-      </header>
-      <section className="modal-card-body">
-        <strong>この画像をアップロードします。よろしいですか？</strong>
-        <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
-      </section>
-      <footer className="modal-card-foot">
-        <button type="button" className="button is-success">
-          アップロードする
-        </button>
-        <button type="button" className="button">
-          キャンセル
-        </button>
-      </footer>
+const CatImageUploadConfirmModal: React.FC<Props> = ({
+  isOpen,
+  onClickCancel,
+  onClickUpload,
+  imagePreviewUrl,
+}) => (
+  <Modal isOpen={isOpen} ariaHideApp={false}>
+    <div className="modal is-active">
+      <div className="modal-background" />
+      <div className="modal-card">
+        <header className="modal-card-head">
+          <p className="modal-card-title">猫ちゃん画像アップロード確認</p>
+          <button
+            type="button"
+            className="delete"
+            aria-label="close"
+            onClick={onClickCancel}
+          />
+        </header>
+        <section className="modal-card-body">
+          <strong>この画像をアップロードします。よろしいですか？</strong>
+          <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
+        </section>
+        <footer className="modal-card-foot">
+          <button
+            type="button"
+            className="button is-success"
+            onClick={onClickUpload}
+          >
+            アップロードする
+          </button>
+          <button type="button" className="button" onClick={onClickCancel}>
+            キャンセル
+          </button>
+        </footer>
+      </div>
     </div>
-  </div>
+  </Modal>
 );
 
 export default CatImageUploadConfirmModal;

--- a/src/components/CatImageUploadConfirmModal.tsx
+++ b/src/components/CatImageUploadConfirmModal.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import UploadCatImagePreview from './UploadCatImagePreview';
+
+type Props = {
+  imagePreviewUrl: string;
+};
+
+const CatImageUploadConfirmModal: React.FC<Props> = ({ imagePreviewUrl }) => (
+  <div className="modal is-active">
+    <div className="modal-background" />
+    <div className="modal-card">
+      <header className="modal-card-head">
+        <p className="modal-card-title">猫ちゃん画像アップロード確認</p>
+        <button type="button" className="delete" aria-label="close" />
+      </header>
+      <section className="modal-card-body">
+        <strong>この画像をアップロードします。よろしいですか？</strong>
+        <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
+      </section>
+      <footer className="modal-card-foot">
+        <button type="button" className="button is-success">
+          アップロードする
+        </button>
+        <button type="button" className="button">
+          キャンセル
+        </button>
+      </footer>
+    </div>
+  </div>
+);
+
+export default CatImageUploadConfirmModal;

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -157,65 +157,67 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   };
 
   return (
-    <div className="container">
-      <CatImageUploadDescription />
-      <form method="post" onSubmit={handleOnSubmit}>
-        <div className="file has-name is-boxed">
-          <label className="file-label mb-3" htmlFor="cat-image-upload">
-            <input
-              className="file-input"
-              type="file"
-              name="uploadedCatImage"
-              id="cat-image-upload"
-              onChange={handleFileUpload}
-            />
-            <span className="file-cta">
-              <span className="file-icon">
-                <i className="fas fa-upload" />
+    <>
+      <div className="container">
+        <CatImageUploadDescription />
+        <form method="post" onSubmit={handleOnSubmit}>
+          <div className="file has-name is-boxed">
+            <label className="file-label mb-3" htmlFor="cat-image-upload">
+              <input
+                className="file-input"
+                type="file"
+                name="uploadedCatImage"
+                id="cat-image-upload"
+                onChange={handleFileUpload}
+              />
+              <span className="file-cta">
+                <span className="file-icon">
+                  <i className="fas fa-upload" />
+                </span>
+                <span className="file-label">猫ちゃん画像を選択</span>
               </span>
-              <span className="file-label">猫ちゃん画像を選択</span>
-            </span>
-          </label>
-        </div>
-        <button
-          className="button is-primary m-4"
-          type="submit"
-          disabled={shouldDisableButton()}
-        >
-          アップロードする
-        </button>
+            </label>
+          </div>
+          <button
+            className="button is-primary m-4"
+            type="submit"
+            disabled={shouldDisableButton()}
+          >
+            アップロードする
+          </button>
+          {uploaded ? (
+            <CopyMarkdownSourceButton
+              createdLgtmImageUrl={createdLgtmImageProps.createdLgtmImageUrl}
+            />
+          ) : (
+            ''
+          )}
+        </form>
+        {isLoading ? <ProgressBar /> : ''}
+        {imagePreviewUrl && !uploaded ? (
+          <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
+        ) : (
+          ''
+        )}
+        {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
+        {uploaded ? <CatImageUploadSuccessMessage /> : ''}
+        {uploaded ? <AfterUploadWarningMessage /> : ''}
         {uploaded ? (
-          <CopyMarkdownSourceButton
+          <CreatedLgtmImage
+            imagePreviewUrl={createdLgtmImageProps.imagePreviewUrl}
             createdLgtmImageUrl={createdLgtmImageProps.createdLgtmImageUrl}
           />
         ) : (
           ''
         )}
-      </form>
-      {isLoading ? <ProgressBar /> : ''}
-      {imagePreviewUrl && !uploaded ? (
-        <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
-      ) : (
-        ''
-      )}
+      </div>
       <CatImageUploadConfirmModal
         isOpen={modalIsOpen}
         onClickCancel={closeModal}
         onClickUpload={onClickUpload}
         imagePreviewUrl={imagePreviewUrl as string}
       />
-      {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
-      {uploaded ? <CatImageUploadSuccessMessage /> : ''}
-      {uploaded ? <AfterUploadWarningMessage /> : ''}
-      {uploaded ? (
-        <CreatedLgtmImage
-          imagePreviewUrl={createdLgtmImageProps.imagePreviewUrl}
-          createdLgtmImageUrl={createdLgtmImageProps.createdLgtmImageUrl}
-        />
-      ) : (
-        ''
-      )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -13,6 +13,7 @@ import ProgressBar from './ProgressBar';
 import { sendUploadCatImage } from '../infrastructures/utils/gtag';
 import CopyMarkdownSourceButton from './CopyMarkdownSourceButton';
 import AfterUploadWarningMessage from './AfterUploadWarningMessage';
+import CatImageUploadConfirmModal from './CatImageUploadConfirmModal';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -31,6 +32,15 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   const [errorMessage, setErrorMessage] = useState<string>();
   const [uploaded, setUploaded] = useState<boolean>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [modalIsOpen, setModalIsOpen] = React.useState(false);
+
+  const openModal = () => {
+    setModalIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalIsOpen(false);
+  };
 
   // TODO どの画像を許可するかはビジネスロジックとして意味があるので分離する
   const isValidFileType = (fileType: string): boolean =>
@@ -99,37 +109,36 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     }
   };
 
-  const handleOnSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // TODO 以下の課題で window.confirm の利用はやめてちゃんとしたモーダルを使った処理に変更する
-    // https://github.com/nekochans/lgtm-cat-frontend/issues/93
-    if (window.confirm('この画像をアップロードします。よろしいですか？')) {
-      setIsLoading(true);
 
-      const uploadCatResult = await uploadCatImage({
-        image: base64Image,
-        imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
-      });
+    openModal();
+  };
 
-      if (isSuccessResult(uploadCatResult)) {
-        setUploaded(true);
-        setErrorMessage('');
-        setCreatedLgtmImageUrl(uploadCatResult.value.imageUrl);
-        setIsLoading(false);
-      } else {
-        setErrorMessage(createDisplayErrorMessage(uploadCatResult.value));
-        setImagePreviewUrl('');
-        setUploadImageExtension('');
-        setCreatedLgtmImageUrl('');
-        setIsLoading(false);
-      }
+  const onClickUpload = async () => {
+    closeModal();
 
-      sendUploadCatImage('upload_cat_image_button');
+    setIsLoading(true);
 
-      return true;
+    const uploadCatResult = await uploadCatImage({
+      image: base64Image,
+      imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
+    });
+
+    if (isSuccessResult(uploadCatResult)) {
+      setUploaded(true);
+      setErrorMessage('');
+      setCreatedLgtmImageUrl(uploadCatResult.value.imageUrl);
+      setIsLoading(false);
+    } else {
+      setErrorMessage(createDisplayErrorMessage(uploadCatResult.value));
+      setImagePreviewUrl('');
+      setUploadImageExtension('');
+      setCreatedLgtmImageUrl('');
+      setIsLoading(false);
     }
 
-    return false;
+    sendUploadCatImage('upload_cat_image_button');
   };
 
   const shouldDisableButton = (): boolean => {
@@ -189,6 +198,12 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       ) : (
         ''
       )}
+      <CatImageUploadConfirmModal
+        isOpen={modalIsOpen}
+        onClickCancel={closeModal}
+        onClickUpload={onClickUpload}
+        imagePreviewUrl={imagePreviewUrl as string}
+      />
       {errorMessage ? <CatImageUploadError message={errorMessage} /> : ''}
       {uploaded ? <CatImageUploadSuccessMessage /> : ''}
       {uploaded ? <AfterUploadWarningMessage /> : ''}

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -215,7 +215,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
         isOpen={modalIsOpen}
         onClickCancel={closeModal}
         onClickUpload={onClickUpload}
-        imagePreviewUrl={imagePreviewUrl as string}
+        imagePreviewUrl={imagePreviewUrl}
       />
     </>
   );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/93

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue93add-modal-nekochans.vercel.app/upload

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/93 のDoneの定義を満たしている事

# スクリーンショット

![Modal](https://user-images.githubusercontent.com/11032365/143595551-5cb47884-969c-49c6-93a0-92844a0b4dd3.png)

# 変更点概要

`CatImageUploadConfirmModal` を実装。

Modalの制御には一番メジャーな `react-modal` を使用。

「アップロードする」を押下すると、アップロードAPIへ通信を行い、アップロードを実行する。

「キャンセル」を押すと何もせずにModalを閉じる。

# レビュアーに重点的にチェックして欲しい点

デザイン面と対応方針に問題がないか確認してもらえると:pray:

# 補足情報

現時点では少し不便な点がある、以下の2点。

- ~~Modal右上の☓Buttonを押下した際もModalが閉じるようになっているが反応しない時がある~~
- Modalの外をクリックした際もModalが閉じて欲しいが現状そうなっていない

>Modal右上の☓Buttonを押下した際もModalが閉じるようになっているが反応しない時がある

https://github.com/nekochans/lgtm-cat-frontend/pull/122/commits/285e266ee3868b2f7dc0a0fdc66da931185eb5bd で解消済。

https://github.com/nekochans/lgtm-cat-frontend/issues/123 で解消する。