### PR TITLE
ランダムでLGTM画像を取得するAPIの向き先を作成したバックエンドAPIに変更

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,4 @@ build/
 coverage/
 .eslintrc.js
 next-env.d.ts
-test/setupTests.ts
 *.config.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
-  setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   images: {
-    domains: ['lgtm-images.lgtmeow.com'],
+    domains: ['lgtm-images.lgtmeow.com', 'stg-lgtm-images.lgtmeow.com'],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-prefer-arrow": "^1.2.3",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "fetch-mock-jest": "^1.5.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.2.0",
         "jest-fetch-mock": "^3.0.3",
@@ -12995,6 +12996,104 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "dependencies": {
+        "fetch-mock": "^9.11.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -15736,6 +15835,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "node_modules/is-supported-regexp-flag": {
       "version": "1.0.1",
@@ -19093,6 +19198,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -41342,6 +41453,73 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "requires": {
+        "fetch-mock": "^9.11.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -43425,6 +43603,12 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+      "dev": true
     },
     "is-supported-regexp-flag": {
       "version": "1.0.1",
@@ -45998,6 +46182,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.merge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "fetch-mock-jest": "^1.5.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.2.0",
-        "jest-fetch-mock": "^3.0.3",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.6",
         "prettier": "^2.4.0",
@@ -10381,15 +10380,6 @@
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -17025,16 +17015,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-fetch-mock": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
-      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
-      "dev": true,
-      "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "promise-polyfill": "^8.1.3"
       }
     },
     "node_modules/jest-get-type": {
@@ -24216,12 +24196,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "devOptional": true
-    },
-    "node_modules/promise-polyfill": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
-      "dev": true
     },
     "node_modules/promise.allsettled": {
       "version": "1.0.4",
@@ -39375,15 +39349,6 @@
         "warning": "^4.0.3"
       }
     },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -44496,16 +44461,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "jest-fetch-mock": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
-      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
-      "dev": true,
-      "requires": {
-        "cross-fetch": "^3.0.4",
-        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-get-type": {
@@ -50117,12 +50072,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "devOptional": true
-    },
-    "promise-polyfill": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
-      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
-      "dev": true
     },
     "promise.allsettled": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "fetch-mock-jest": "^1.5.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.2.0",
-    "jest-fetch-mock": "^3.0.3",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.6",
     "prettier": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "fetch-mock-jest": "^1.5.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.2.0",
     "jest-fetch-mock": "^3.0.3",

--- a/src/__tests__/pages/index.spec.tsx
+++ b/src/__tests__/pages/index.spec.tsx
@@ -48,6 +48,6 @@ test('IndexPage Snapshot test', () => {
     ],
   };
 
-  const { asFragment } = render(<IndexPage imageList={testProps.imageList} />);
+  const { asFragment } = render(<IndexPage lgtmImages={testProps.imageList} />);
   expect(asFragment()).toMatchSnapshot();
 });

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -5,7 +5,7 @@ import {
   createFailureResult,
   createSuccessResult,
 } from '../domain/repositories/repositoryResult';
-import { UploadedImage } from '../domain/types/image';
+import { UploadedImage } from '../domain/types/lgtmImage';
 import UploadCatImageAuthError from '../domain/errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';

--- a/src/components/ImageContent.tsx
+++ b/src/components/ImageContent.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react';
 import Image from 'next/image';
-import { Image as ImageType } from '../domain/types/image';
+import { LgtmImage } from '../domain/types/lgtmImage';
 import useClipboardMarkdown from '../hooks/useClipboardMarkdown';
 import { sendCopyMarkdownEvent } from '../infrastructures/utils/gtag';
 
 type Props = {
-  image: ImageType;
+  image: LgtmImage;
 };
 
 const ImageContent: React.FC<Props> = ({ image }: Props) => {

--- a/src/components/ImageList.stories.tsx
+++ b/src/components/ImageList.stories.tsx
@@ -49,5 +49,5 @@ export const testProps = {
 };
 
 export const showImageListWithProps = (): JSX.Element => (
-  <ImageList imageList={testProps.imageList} />
+  <ImageList lgtmImages={testProps.imageList} />
 );

--- a/src/components/ImageList.tsx
+++ b/src/components/ImageList.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import ImageRow from './ImageRow';
-import { Image } from '../domain/types/image';
+import { LgtmImages } from '../domain/types/lgtmImage';
 
-type Props = {
-  imageList: Image[];
-};
+type Props = LgtmImages;
 
-const ImageList: React.FC<Props> = ({ imageList }: Props) => (
+const ImageList: React.FC<Props> = ({ lgtmImages }: Props) => (
   <section>
     <div className="container">
-      <ImageRow imageList={imageList.slice(0, 3)} />
-      <ImageRow imageList={imageList.slice(3, 6)} />
-      <ImageRow imageList={imageList.slice(6, 9)} />
+      <ImageRow lgtmImages={lgtmImages.slice(0, 3)} />
+      <ImageRow lgtmImages={lgtmImages.slice(3, 6)} />
+      <ImageRow lgtmImages={lgtmImages.slice(6, 9)} />
     </div>
   </section>
 );

--- a/src/components/ImageRow.stories.tsx
+++ b/src/components/ImageRow.stories.tsx
@@ -8,7 +8,7 @@ export default {
 };
 
 export const testProps = {
-  imageList: [
+  lgtmImages: [
     {
       id: 1,
       url: '/cat.jpeg',
@@ -25,5 +25,5 @@ export const testProps = {
 };
 
 export const showImageRowWithProps = (): JSX.Element => (
-  <ImageRow imageList={testProps.imageList} />
+  <ImageRow lgtmImages={testProps.lgtmImages} />
 );

--- a/src/components/ImageRow.tsx
+++ b/src/components/ImageRow.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { Image } from '../domain/types/image';
+import { LgtmImages } from '../domain/types/lgtmImage';
 import ImageContent from './ImageContent';
 
-type Props = {
-  imageList: Image[];
-};
+type Props = LgtmImages;
 
-const ImageRow: React.FC<Props> = ({ imageList }: Props) => (
+const ImageRow: React.FC<Props> = ({ lgtmImages }: Props) => (
   <div className="columns">
-    {imageList.map((image) => (
+    {lgtmImages.map((image) => (
       <ImageContent image={image} key={image.id} />
     ))}
   </div>

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -33,3 +33,7 @@ const lgtmeowApiUrl = (): string =>
 
 // この関数はサーバーサイドでしか動作しない
 export const uploadCatImageUrl = (): string => `${lgtmeowApiUrl()}/lgtm-images`;
+
+// この関数はサーバーサイドでしか動作しない
+export const fetchLgtmImagesUrl = (): string =>
+  `${lgtmeowApiUrl()}/lgtm-images`;

--- a/src/containers/ImageLIst.tsx
+++ b/src/containers/ImageLIst.tsx
@@ -8,7 +8,7 @@ import { pathList } from '../constants/url';
 const ImageListContainer: React.FC = () => {
   const state = useAppState();
 
-  if (state.isFailedFetchImages) {
+  if (state.isFailedFetchLgtmImages) {
     return (
       <Error
         title="Error"
@@ -23,6 +23,6 @@ const ImageListContainer: React.FC = () => {
     );
   }
 
-  return <ImageList imageList={state.imageList} />;
+  return <ImageList lgtmImages={state.lgtmImages} />;
 };
 export default ImageListContainer;

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -5,20 +5,22 @@ import { useSetAppState } from '../stores/contexts/AppStateContext';
 import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
 import RandomButton from '../components/RandomButton';
 import { sendFetchRandomImages } from '../infrastructures/utils/gtag';
+import { isSuccessResult } from '../domain/repositories/repositoryResult';
 
 const RandomButtonContainer: React.FC = () => {
   const setAppState = useSetAppState();
 
   const handleRandom = async () => {
-    try {
-      const lgtmImagesResponse = await fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
+
+    if (isSuccessResult(lgtmImagesResponse)) {
       setAppState({
-        lgtmImages: lgtmImagesResponse.lgtmImages,
+        lgtmImages: lgtmImagesResponse.value.lgtmImages,
         isFailedFetchLgtmImages: false,
       });
 
       sendFetchRandomImages('fetch_random_images_button');
-    } catch (e) {
+    } else {
       setAppState({ lgtmImages: [], isFailedFetchLgtmImages: true });
     }
   };

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import throttle from 'lodash/throttle';
 import { useSetAppState } from '../stores/contexts/AppStateContext';
-import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
+import { fetchLgtmImagesInRandomWithClient } from '../infrastructures/repositories/api/fetch/imageRepository';
 import RandomButton from '../components/RandomButton';
 import { sendFetchRandomImages } from '../infrastructures/utils/gtag';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
@@ -11,7 +11,7 @@ const RandomButtonContainer: React.FC = () => {
   const setAppState = useSetAppState();
 
   const handleRandom = async () => {
-    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithClient();
 
     if (isSuccessResult(lgtmImagesResponse)) {
       setAppState({

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -11,12 +11,15 @@ const RandomButtonContainer: React.FC = () => {
 
   const handleRandom = async () => {
     try {
-      const imageList = await fetchRandomImageList();
-      setAppState({ imageList: imageList.images, isFailedFetchImages: false });
+      const lgtmImagesResponse = await fetchRandomImageList();
+      setAppState({
+        lgtmImages: lgtmImagesResponse.lgtmImages,
+        isFailedFetchLgtmImages: false,
+      });
 
       sendFetchRandomImages('fetch_random_images_button');
     } catch (e) {
-      setAppState({ imageList: [], isFailedFetchImages: true });
+      setAppState({ lgtmImages: [], isFailedFetchLgtmImages: true });
     }
   };
   const handleRandomThrottled = throttle(() => handleRandom(), 500);

--- a/src/containers/RandomButton.tsx
+++ b/src/containers/RandomButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import throttle from 'lodash/throttle';
 import { useSetAppState } from '../stores/contexts/AppStateContext';
-import { fetchRandomImageList } from '../infrastructures/repositories/api/fetch/imageRepository';
+import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
 import RandomButton from '../components/RandomButton';
 import { sendFetchRandomImages } from '../infrastructures/utils/gtag';
 
@@ -11,7 +11,7 @@ const RandomButtonContainer: React.FC = () => {
 
   const handleRandom = async () => {
     try {
-      const lgtmImagesResponse = await fetchRandomImageList();
+      const lgtmImagesResponse = await fetchLgtmImagesInRandom();
       setAppState({
         lgtmImages: lgtmImagesResponse.lgtmImages,
         isFailedFetchLgtmImages: false,

--- a/src/domain/errors/FetchLgtmImagesInRandomAuthError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRandomAuthError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class FetchLgtmImagesInRandomAuthError extends ExtensibleCustomError {}

--- a/src/domain/errors/FetchLgtmImagesInRandomError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRandomError.ts
@@ -1,0 +1,3 @@
+import ExtensibleCustomError from 'extensible-custom-error';
+
+export default class FetchLgtmImagesInRandomError extends ExtensibleCustomError {}

--- a/src/domain/errors/FetchRandomImageListError.ts
+++ b/src/domain/errors/FetchRandomImageListError.ts
@@ -1,3 +1,0 @@
-import ExtensibleCustomError from 'extensible-custom-error';
-
-export default class FetchRandomImageListError extends ExtensibleCustomError {}

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -4,8 +4,11 @@ import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageValidationError from '../errors/UploadCatImageValidationError';
 import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
+import FetchLgtmImagesInRandomError from '../errors/FetchLgtmImagesInRandomError';
 
-export type FetchLgtmImagesInRandom = () => Promise<LgtmImages>;
+export type FetchLgtmImagesInRandom = () => Promise<
+  RepositoryResult<LgtmImages, FetchLgtmImagesInRandomError>
+>;
 
 export type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';
 

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -5,7 +5,7 @@ import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLarg
 import UploadCatImageValidationError from '../errors/UploadCatImageValidationError';
 import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
 
-export type FetchRandomImageList = () => Promise<LgtmImages>;
+export type FetchLgtmImagesInRandom = () => Promise<LgtmImages>;
 
 export type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';
 

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,11 +1,11 @@
-import { ImageList, UploadedImage } from '../types/image';
+import { LgtmImages, UploadedImage } from '../types/lgtmImage';
 import { RepositoryResult } from './repositoryResult';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageValidationError from '../errors/UploadCatImageValidationError';
 import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
 
-export type FetchRandomImageList = () => Promise<ImageList>;
+export type FetchRandomImageList = () => Promise<LgtmImages>;
 
 export type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';
 

--- a/src/domain/types/image.ts
+++ b/src/domain/types/image.ts
@@ -1,9 +1,0 @@
-export type Image = { id: number; url: string };
-
-export type ImageList = {
-  images: Image[];
-};
-
-export type UploadedImage = {
-  imageUrl: string;
-};

--- a/src/domain/types/lgtmImage.ts
+++ b/src/domain/types/lgtmImage.ts
@@ -1,0 +1,9 @@
+export type LgtmImage = { id: number; url: string };
+
+export type LgtmImages = {
+  lgtmImages: LgtmImage[];
+};
+
+export type UploadedImage = {
+  imageUrl: string;
+};

--- a/src/infrastructures/repositories/api/fetch/__tests__/authTokenRepository/issueAccessToken.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/authTokenRepository/issueAccessToken.spec.ts
@@ -1,11 +1,11 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import fetch from 'jest-fetch-mock';
+import fetchMock from 'fetch-mock-jest';
 import { issueAccessToken } from '../../authTokenRepository';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import { cognitoTokenEndpointUrl } from '../../../../../../constants/url';
 
 describe('authTokenRepository.ts issueAccessToken TestCases', () => {
   beforeEach(() => {
-    fetch.resetMocks();
+    fetchMock.mockReset();
   });
 
   it('should be able to issue an access token', async () => {
@@ -16,12 +16,7 @@ describe('authTokenRepository.ts issueAccessToken TestCases', () => {
       token_type: 'Bearer',
     };
 
-    const mockParams = {
-      status: 200,
-      statusText: 'OK',
-    };
-
-    fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
+    fetchMock.post(cognitoTokenEndpointUrl(), { status: 200, body: mockBody });
 
     const accessTokenResult = await issueAccessToken();
 

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
@@ -2,6 +2,7 @@
 import fetch from 'jest-fetch-mock';
 import { fetchLgtmImagesInRandom } from '../../imageRepository';
 import FetchLgtmImagesInRandomError from '../../../../../../domain/errors/FetchLgtmImagesInRandomError';
+import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
 
 describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
   beforeEach(() => {
@@ -57,9 +58,10 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const lgtmImages = await fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
 
-    expect(lgtmImages).toStrictEqual(mockBody);
+    expect(isSuccessResult(lgtmImagesResponse)).toBeTruthy();
+    expect(lgtmImagesResponse.value).toStrictEqual(mockBody);
   });
 
   it('should return an Error because the HTTP status is not 200', async () => {
@@ -72,8 +74,11 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const promise = fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
 
-    await expect(promise).rejects.toThrowError(FetchLgtmImagesInRandomError);
+    expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
+    expect(lgtmImagesResponse.value).toStrictEqual(
+      new FetchLgtmImagesInRandomError(),
+    );
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import fetch from 'jest-fetch-mock';
-import { fetchRandomImageList } from '../../imageRepository';
-import FetchRandomImageListError from '../../../../../../domain/errors/FetchRandomImageListError';
+import { fetchLgtmImagesInRandom } from '../../imageRepository';
+import FetchLgtmImagesInRandomError from '../../../../../../domain/errors/FetchLgtmImagesInRandomError';
 
-describe('imageRepository.ts fetchRandomImageList TestCases', () => {
+describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
   beforeEach(() => {
     fetch.resetMocks();
   });
@@ -57,7 +57,7 @@ describe('imageRepository.ts fetchRandomImageList TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const jwkList = await fetchRandomImageList();
+    const jwkList = await fetchLgtmImagesInRandom();
 
     expect(jwkList).toStrictEqual(mockBody);
   });
@@ -72,10 +72,10 @@ describe('imageRepository.ts fetchRandomImageList TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const jwkListPromise = fetchRandomImageList();
+    const jwkListPromise = fetchLgtmImagesInRandom();
 
     await expect(jwkListPromise).rejects.toThrowError(
-      FetchRandomImageListError,
+      FetchLgtmImagesInRandomError,
     );
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
@@ -8,9 +8,9 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
     fetch.resetMocks();
   });
 
-  it('should be able to fetch random image list', async () => {
+  it('should be able to fetch LGTM Images', async () => {
     const mockBody = {
-      images: [
+      lgtmImages: [
         {
           id: 5,
           url: '/cat.jpeg',
@@ -57,9 +57,9 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const jwkList = await fetchLgtmImagesInRandom();
+    const lgtmImages = await fetchLgtmImagesInRandom();
 
-    expect(jwkList).toStrictEqual(mockBody);
+    expect(lgtmImages).toStrictEqual(mockBody);
   });
 
   it('should return an Error because the HTTP status is not 200', async () => {
@@ -72,10 +72,8 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const jwkListPromise = fetchLgtmImagesInRandom();
+    const promise = fetchLgtmImagesInRandom();
 
-    await expect(jwkListPromise).rejects.toThrowError(
-      FetchLgtmImagesInRandomError,
-    );
+    await expect(promise).rejects.toThrowError(FetchLgtmImagesInRandomError);
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithClient.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithClient.spec.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import fetch from 'jest-fetch-mock';
-import { fetchLgtmImagesInRandom } from '../../imageRepository';
+import { fetchLgtmImagesInRandomWithClient } from '../../imageRepository';
 import FetchLgtmImagesInRandomError from '../../../../../../domain/errors/FetchLgtmImagesInRandomError';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
 
-describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
+describe('imageRepository.ts fetchLgtmImagesInRandomWithClient TestCases', () => {
   beforeEach(() => {
     fetch.resetMocks();
   });
@@ -58,7 +58,7 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithClient();
 
     expect(isSuccessResult(lgtmImagesResponse)).toBeTruthy();
     expect(lgtmImagesResponse.value).toStrictEqual(mockBody);
@@ -74,7 +74,7 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
 
     fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
 
-    const lgtmImagesResponse = await fetchLgtmImagesInRandom();
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithClient();
 
     expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
     expect(lgtmImagesResponse.value).toStrictEqual(

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithClient.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithClient.spec.ts
@@ -1,12 +1,12 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import fetch from 'jest-fetch-mock';
+import fetchMock from 'fetch-mock-jest';
 import { fetchLgtmImagesInRandomWithClient } from '../../imageRepository';
 import FetchLgtmImagesInRandomError from '../../../../../../domain/errors/FetchLgtmImagesInRandomError';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import { apiList } from '../../../../../../constants/url';
 
 describe('imageRepository.ts fetchLgtmImagesInRandomWithClient TestCases', () => {
   beforeEach(() => {
-    fetch.resetMocks();
+    fetchMock.mockReset();
   });
 
   it('should be able to fetch LGTM Images', async () => {
@@ -51,12 +51,7 @@ describe('imageRepository.ts fetchLgtmImagesInRandomWithClient TestCases', () =>
       ],
     };
 
-    const mockParams = {
-      status: 200,
-      statusText: 'OK',
-    };
-
-    fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
+    fetchMock.get(apiList.fetchLgtmImages, { status: 200, body: mockBody });
 
     const lgtmImagesResponse = await fetchLgtmImagesInRandomWithClient();
 
@@ -67,12 +62,7 @@ describe('imageRepository.ts fetchLgtmImagesInRandomWithClient TestCases', () =>
   it('should return an Error because the HTTP status is not 200', async () => {
     const mockBody = { message: 'Internal Server Error' };
 
-    const mockParams = {
-      status: 500,
-      statusText: 'Internal Server Error',
-    };
-
-    fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
+    fetchMock.get(apiList.fetchLgtmImages, { status: 500, body: mockBody });
 
     const lgtmImagesResponse = await fetchLgtmImagesInRandomWithClient();
 

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithServer.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandomWithServer.spec.ts
@@ -1,0 +1,118 @@
+import fetchMock from 'fetch-mock-jest';
+import { fetchLgtmImagesInRandomWithServer } from '../../imageRepository';
+import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import {
+  cognitoTokenEndpointUrl,
+  fetchLgtmImagesUrl,
+} from '../../../../../../constants/url';
+import FetchLgtmImagesInRandomError from '../../../../../../domain/errors/FetchLgtmImagesInRandomError';
+import FetchLgtmImagesInRandomAuthError from '../../../../../../domain/errors/FetchLgtmImagesInRandomAuthError';
+
+describe('imageRepository.ts fetchLgtmImagesInRandomWithServer TestCases', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('should be able to fetch LGTM Images', async () => {
+    const fetchLgtmImagesMockBody = {
+      lgtmImages: [
+        {
+          id: 1,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/71a7a8d4-33c2-4399-9c5b-4ea585c06580.webp',
+        },
+        {
+          id: 2,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/98f86ac2-7227-44dd-bfc9-1d424b45813d.webp',
+        },
+        {
+          id: 3,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/bf3bbfb8-56d3-453d-811c-0f5fd9dfa4d0.webp',
+        },
+        {
+          id: 4,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/44dc9b25-a0df-4726-a2bd-fccb1e0e832e.webp',
+        },
+        {
+          id: 5,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/62b7b519-9811-4e05-8c39-3c6dbab0a42d.webp',
+        },
+        {
+          id: 6,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/01/6c7ab983-4aa1-4af4-ab37-f1327899cc26.webp',
+        },
+        {
+          id: 7,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/01/e549cf62-c8e2-4729-af9e-b35e27bb34e3.webp',
+        },
+        {
+          id: 8,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/01/e62cf588-057c-43a1-82a0-035d7c0e67bf.webp',
+        },
+        {
+          id: 9,
+          url: 'https://lgtm-images.lgtmeow.com/2021/03/16/22/03b4b6a8-931c-47cf-b2e5-ff8218a67b08.webp',
+        },
+      ],
+    };
+
+    const issueAccessTokenMockBody = {
+      access_token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    };
+
+    fetchMock
+      .post(cognitoTokenEndpointUrl(), {
+        status: 200,
+        body: issueAccessTokenMockBody,
+      })
+      .get(fetchLgtmImagesUrl(), {
+        status: 200,
+        body: fetchLgtmImagesMockBody,
+      });
+
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithServer();
+
+    expect(isSuccessResult(lgtmImagesResponse)).toBeTruthy();
+    expect(lgtmImagesResponse.value).toStrictEqual(fetchLgtmImagesMockBody);
+  });
+
+  it('should return an FetchLgtmImagesInRandomAuthError because Failed to issueAccessToken', async () => {
+    const mockBody = { message: 'Internal Server Error' };
+
+    fetchMock.post(cognitoTokenEndpointUrl(), { status: 500, body: mockBody });
+
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithServer();
+
+    expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
+    expect(lgtmImagesResponse.value).toStrictEqual(
+      new FetchLgtmImagesInRandomAuthError(),
+    );
+  });
+
+  it('should return an FetchLgtmImagesInRandomError because Failed to fetch LGTM Images', async () => {
+    const mockBody = { message: 'Internal Server Error' };
+
+    const issueAccessTokenMockBody = {
+      access_token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    };
+
+    fetchMock
+      .post(cognitoTokenEndpointUrl(), {
+        status: 200,
+        body: issueAccessTokenMockBody,
+      })
+      .get(fetchLgtmImagesUrl(), { status: 500, body: mockBody });
+
+    const lgtmImagesResponse = await fetchLgtmImagesInRandomWithServer();
+
+    expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
+    expect(lgtmImagesResponse.value).toStrictEqual(
+      new FetchLgtmImagesInRandomError(),
+    );
+  });
+});

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/uploadCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/uploadCatImage.spec.ts
@@ -1,12 +1,12 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import fetch from 'jest-fetch-mock';
+import fetchMock from 'fetch-mock-jest';
 import { uploadCatImage } from '../../imageRepository';
 import { UploadCatImageRequest } from '../../../../../../domain/repositories/imageRepository';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import { apiList } from '../../../../../../constants/url';
 
 describe('imageRepository.ts uploadCatImage TestCases', () => {
   beforeEach(() => {
-    fetch.resetMocks();
+    fetchMock.mockReset();
   });
 
   it('should return the LGTM image URL', async () => {
@@ -15,12 +15,7 @@ describe('imageRepository.ts uploadCatImage TestCases', () => {
         'https://lgtm-images.lgtmeow.com/2021/03/16/22/ff92782d-fae7-4a7a-b042-adbfccf64826.webp',
     };
 
-    const mockParams = {
-      status: 202,
-      statusText: 'Accepted',
-    };
-
-    fetch.mockResponseOnce(JSON.stringify(mockBody), mockParams);
+    fetchMock.post(apiList.uploadCatImage, { status: 202, body: mockBody });
 
     const request: UploadCatImageRequest = {
       image: '',

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -1,9 +1,9 @@
 import { LgtmImages, UploadedImage } from '../../../../domain/types/lgtmImage';
 import {
-  FetchRandomImageList,
+  FetchLgtmImagesInRandom,
   UploadCatImage,
 } from '../../../../domain/repositories/imageRepository';
-import FetchRandomImageListError from '../../../../domain/errors/FetchRandomImageListError';
+import FetchLgtmImagesInRandomError from '../../../../domain/errors/FetchLgtmImagesInRandomError';
 import { apiList } from '../../../../constants/url';
 import { UploadedImageResponse } from '../../../../pages/api/lgtm/images';
 import {
@@ -15,11 +15,11 @@ import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCat
 import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
 
-export const fetchRandomImageList: FetchRandomImageList = async () => {
+export const fetchLgtmImagesInRandom: FetchLgtmImagesInRandom = async () => {
   const response = await fetch(apiList.fetchLgtmImages);
 
   if (!response.ok) {
-    throw new FetchRandomImageListError();
+    throw new FetchLgtmImagesInRandomError();
   }
 
   return (await response.json()) as LgtmImages;

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -19,10 +19,12 @@ export const fetchLgtmImagesInRandom: FetchLgtmImagesInRandom = async () => {
   const response = await fetch(apiList.fetchLgtmImages);
 
   if (!response.ok) {
-    throw new FetchLgtmImagesInRandomError();
+    return createFailureResult(new FetchLgtmImagesInRandomError());
   }
 
-  return (await response.json()) as LgtmImages;
+  const lgtmImages = (await response.json()) as LgtmImages;
+
+  return createSuccessResult<LgtmImages>(lgtmImages);
 };
 
 export const uploadCatImage: UploadCatImage = async (request) => {

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -1,4 +1,4 @@
-import { ImageList, UploadedImage } from '../../../../domain/types/image';
+import { LgtmImages, UploadedImage } from '../../../../domain/types/lgtmImage';
 import {
   FetchRandomImageList,
   UploadCatImage,
@@ -22,7 +22,7 @@ export const fetchRandomImageList: FetchRandomImageList = async () => {
     throw new FetchRandomImageListError();
   }
 
-  return (await response.json()) as ImageList;
+  return (await response.json()) as LgtmImages;
 };
 
 export const uploadCatImage: UploadCatImage = async (request) => {

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -15,17 +15,18 @@ import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCat
 import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
 
-export const fetchLgtmImagesInRandom: FetchLgtmImagesInRandom = async () => {
-  const response = await fetch(apiList.fetchLgtmImages);
+export const fetchLgtmImagesInRandomWithClient: FetchLgtmImagesInRandom =
+  async () => {
+    const response = await fetch(apiList.fetchLgtmImages);
 
-  if (!response.ok) {
-    return createFailureResult(new FetchLgtmImagesInRandomError());
-  }
+    if (!response.ok) {
+      return createFailureResult(new FetchLgtmImagesInRandomError());
+    }
 
-  const lgtmImages = (await response.json()) as LgtmImages;
+    const lgtmImages = (await response.json()) as LgtmImages;
 
-  return createSuccessResult<LgtmImages>(lgtmImages);
-};
+    return createSuccessResult<LgtmImages>(lgtmImages);
+  };
 
 export const uploadCatImage: UploadCatImage = async (request) => {
   const options = {

--- a/src/infrastructures/utils/__tests__/randomImages.spec.ts
+++ b/src/infrastructures/utils/__tests__/randomImages.spec.ts
@@ -1,7 +1,7 @@
 import extractRandomImages from '../randomImages';
-import { Image } from '../../../domain/types/image';
+import { LgtmImage } from '../../../domain/types/lgtmImage';
 
-const testImageList: Image[] = [
+const testImageList: LgtmImage[] = [
   {
     id: 1,
     url: '/cat.jpeg',

--- a/src/infrastructures/utils/imageData.ts
+++ b/src/infrastructures/utils/imageData.ts
@@ -1,6 +1,6 @@
-import { Image } from '../../domain/types/image';
+import { LgtmImage } from '../../domain/types/lgtmImage';
 
-const imageData: Image[] = [
+const imageData: LgtmImage[] = [
   {
     id: 0,
     url: 'https://lgtm-images.lgtmeow.com/2021/03/16/00/35afef75-2d6d-4ca1-ab00-fb37f8848fca.webp',

--- a/src/infrastructures/utils/randomImages.ts
+++ b/src/infrastructures/utils/randomImages.ts
@@ -1,6 +1,6 @@
-import { Image } from '../../domain/types/image';
+import { LgtmImage } from '../../domain/types/lgtmImage';
 
-const extractRandomImages = (arr: Image[], n: number): Image[] => {
+const extractRandomImages = (arr: LgtmImage[], n: number): LgtmImage[] => {
   const copy = [...arr];
   const ret = [];
 

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -1,16 +1,14 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import imageData from '../../../infrastructures/utils/imageData';
 import extractRandomImages from '../../../infrastructures/utils/randomImages';
-import { UploadedImage } from '../../../domain/types/image';
+import { LgtmImage, UploadedImage } from '../../../domain/types/lgtmImage';
 import { UploadCatImageRequest } from '../../../domain/repositories/imageRepository';
 import { uploadCatImageUrl } from '../../../constants/url';
 import { issueAccessToken } from '../../../infrastructures/repositories/api/fetch/authTokenRepository';
 import { isSuccessResult } from '../../../domain/repositories/repositoryResult';
 
-type Image = { id: number; url: string };
-
-type ImagesResponse = {
-  images?: Image[];
+type FetchImagesResponse = {
+  lgtmImages?: LgtmImage[];
   error?: {
     code: number;
     message: string;
@@ -27,10 +25,10 @@ export type UploadedImageResponse = {
 
 const imageLength = 9;
 
-const fetchLgtmImages = (res: NextApiResponse<ImagesResponse>) => {
+const fetchLgtmImages = (res: NextApiResponse<FetchImagesResponse>) => {
   const randomImages = extractRandomImages(imageData, imageLength);
   const imagesResponse = {
-    images: randomImages,
+    lgtmImages: randomImages,
   };
 
   return res.status(200).json(imagesResponse);
@@ -98,13 +96,13 @@ const uploadCatImage = async (
 };
 
 const methodNotAllowedErrorResponse = (
-  res: NextApiResponse<ImagesResponse | UploadedImageResponse>,
+  res: NextApiResponse<FetchImagesResponse | UploadedImageResponse>,
 ) =>
   res.status(405).json({ error: { code: 405, message: 'Method Not Allowed' } });
 
 const handler: NextApiHandler = async (
   req: NextApiRequest,
-  res: NextApiResponse<ImagesResponse | UploadedImageResponse>,
+  res: NextApiResponse<FetchImagesResponse | UploadedImageResponse>,
 ): Promise<void> => {
   switch (req.method) {
     case 'GET': {

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -9,7 +9,7 @@ import { fetchLgtmImagesUrl, uploadCatImageUrl } from '../../../constants/url';
 import { issueAccessToken } from '../../../infrastructures/repositories/api/fetch/authTokenRepository';
 import { isSuccessResult } from '../../../domain/repositories/repositoryResult';
 
-type FetchImagesResponse = {
+type FetchLgtmImagesResponse = {
   lgtmImages?: LgtmImage[];
   error?: {
     code: number;
@@ -25,7 +25,7 @@ export type UploadedImageResponse = {
   };
 };
 
-const fetchLgtmImages = async (res: NextApiResponse<FetchImagesResponse>) => {
+const fetchLgtmImages = async (res: NextApiResponse<FetchLgtmImagesResponse>) => {
   const accessTokenResult = await issueAccessToken();
   if (isSuccessResult(accessTokenResult)) {
     const options = {
@@ -114,13 +114,13 @@ const uploadCatImage = async (
 };
 
 const methodNotAllowedErrorResponse = (
-  res: NextApiResponse<FetchImagesResponse | UploadedImageResponse>,
+  res: NextApiResponse<FetchLgtmImagesResponse | UploadedImageResponse>,
 ) =>
   res.status(405).json({ error: { code: 405, message: 'Method Not Allowed' } });
 
 const handler: NextApiHandler = async (
   req: NextApiRequest,
-  res: NextApiResponse<FetchImagesResponse | UploadedImageResponse>,
+  res: NextApiResponse<FetchLgtmImagesResponse | UploadedImageResponse>,
 ): Promise<void> => {
   switch (req.method) {
     case 'GET': {

--- a/src/pages/api/lgtm/images.ts
+++ b/src/pages/api/lgtm/images.ts
@@ -25,7 +25,9 @@ export type UploadedImageResponse = {
   };
 };
 
-const fetchLgtmImages = async (res: NextApiResponse<FetchLgtmImagesResponse>) => {
+const fetchLgtmImages = async (
+  res: NextApiResponse<FetchLgtmImagesResponse>,
+) => {
   const accessTokenResult = await issueAccessToken();
   if (isSuccessResult(accessTokenResult)) {
     const options = {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,13 @@ import React, { useEffect } from 'react';
 import { GetStaticProps } from 'next';
 import DefaultLayout from '../layouts/DefaultLayout';
 import { metaTagList } from '../constants/metaTag';
-import { LgtmImage, LgtmImages } from '../domain/types/lgtmImage';
-import extractRandomImages from '../infrastructures/utils/randomImages';
-import imageData from '../infrastructures/utils/imageData';
+import { LgtmImages } from '../domain/types/lgtmImage';
 import { useSetAppState } from '../stores/contexts/AppStateContext';
 import ImageListContainer from '../containers/ImageLIst';
+import { fetchLgtmImagesInRandomWithServer } from '../infrastructures/repositories/api/fetch/imageRepository';
+import { isSuccessResult } from '../domain/repositories/repositoryResult';
+import extractRandomImages from '../infrastructures/utils/randomImages';
+import imageData from '../infrastructures/utils/imageData';
 
 type Props = LgtmImages;
 
@@ -25,11 +27,20 @@ const IndexPage: React.FC<Props> = ({ lgtmImages }: Props) => {
   );
 };
 
-const imageLength = 9;
-
-// eslint-disable-next-line @typescript-eslint/require-await
 export const getStaticProps: GetStaticProps = async () => {
-  const lgtmImages: LgtmImage[] = extractRandomImages(imageData, imageLength);
+  const lgtmImagesResult = await fetchLgtmImagesInRandomWithServer();
+  if (isSuccessResult(lgtmImagesResult)) {
+    return {
+      props: { lgtmImages: lgtmImagesResult.value.lgtmImages },
+      revalidate: 3600,
+    };
+  }
+
+  // TODO ここに到達した場合、APIでエラーが起きているので通知を送るようにしたい
+  // APIから取得に失敗した場合は静的ファイルに記載されたデータを取得する
+  // 理由としてはエラー表示がCacheされる事を避ける為
+  const imageLength = 9;
+  const lgtmImages = extractRandomImages(imageData, imageLength);
 
   return {
     props: { lgtmImages },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,21 +2,19 @@ import React, { useEffect } from 'react';
 import { GetStaticProps } from 'next';
 import DefaultLayout from '../layouts/DefaultLayout';
 import { metaTagList } from '../constants/metaTag';
-import { Image } from '../domain/types/image';
+import { LgtmImage, LgtmImages } from '../domain/types/lgtmImage';
 import extractRandomImages from '../infrastructures/utils/randomImages';
 import imageData from '../infrastructures/utils/imageData';
 import { useSetAppState } from '../stores/contexts/AppStateContext';
 import ImageListContainer from '../containers/ImageLIst';
 
-type Props = {
-  imageList: Image[];
-};
+type Props = LgtmImages;
 
-const IndexPage: React.FC<Props> = ({ imageList }: Props) => {
+const IndexPage: React.FC<Props> = ({ lgtmImages }: Props) => {
   const setAppState = useSetAppState();
 
   useEffect(() => {
-    setAppState({ imageList, isFailedFetchImages: false });
+    setAppState({ lgtmImages, isFailedFetchLgtmImages: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -31,10 +29,10 @@ const imageLength = 9;
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getStaticProps: GetStaticProps = async () => {
-  const imageList: Image[] = extractRandomImages(imageData, imageLength);
+  const lgtmImages: LgtmImage[] = extractRandomImages(imageData, imageLength);
 
   return {
-    props: { imageList },
+    props: { lgtmImages },
     revalidate: 3600,
   };
 };

--- a/src/stores/contexts/AppStateContext.tsx
+++ b/src/stores/contexts/AppStateContext.tsx
@@ -1,14 +1,14 @@
 import React, { Dispatch, SetStateAction, useContext, useState } from 'react';
-import { Image } from '../../domain/types/image';
+import { LgtmImage } from '../../domain/types/lgtmImage';
 
 export type AppState = {
-  imageList: Image[];
-  isFailedFetchImages: boolean;
+  lgtmImages: LgtmImage[];
+  isFailedFetchLgtmImages: boolean;
 };
 
 const initialAppState: AppState = {
-  imageList: [],
-  isFailedFetchImages: false,
+  lgtmImages: [],
+  isFailedFetchLgtmImages: false,
 };
 
 const AppStateContext = React.createContext<AppState>(initialAppState);

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,3 +1,0 @@
-import fetchMock from 'jest-fetch-mock';
-
-fetchMock.enableMocks();


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/103

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue103change-f-e0beb1-nekochans.vercel.app

# Done の定義

- ランダムでLGTM画像を取得する機能が https://github.com/nekochans/lgtm-cat-api/pull/10 で作成したAPIを利用するようになっている事

# スクリーンショット

なし

# 変更点概要

以下の通り。

変更点が多くなってしまったので差分を少しでも見やすくする為に各項目毎にコミットIDを貼っている。

## 1 APIのレスポンスが `lgtmImages` だったのでフロント側も合わせて修正

- https://github.com/nekochans/lgtm-cat-frontend/pull/129/commits/594e79180b05eeb243d3893968a07050725b61e8
- https://github.com/nekochans/lgtm-cat-frontend/pull/129/commits/3cf65530fac2de9728d9dcef1a5e7bb2332beacd

## 2 `UploadCatImage` と同じように `RepositoryResult` を使った設計に変更

https://github.com/nekochans/lgtm-cat-frontend/pull/105#discussion_r688260550 で宣言していた通り、設計を変更。

詳しくは https://github.com/nekochans/lgtm-cat-frontend/pull/129/commits/ba7d7a50fbeb542f2f327016517371546470d365 を参照。

## 3 クライアントサイドとサーバーサイドでそれぞれ別の関数を定義して使い分けるように変更

関数のインターフェースは共通だが、以下の2つの関数を定義した。

- `fetchLgtmImagesInRandomWithClient`  （他の猫ちゃんを表示を押下した際に呼ばれる）
- `fetchLgtmImagesInRandomWithServer` （`src/pages/index.tsx` 内のISRを実行する際に利用される）

Next.jsの仕様上 `getStaticProps` 内で `/api` のAPIをコールする事が出来なくなっているので、このように対応を行った。

## 4 fetchのモックは `fetch-mock-jest` を利用するように変更

名前が似ているのでややこしいが以下の通り。

- https://github.com/jefflau/jest-fetch-mock （以前まで使っていたやつ）
- https://www.npmjs.com/package/fetch-mock-jest （今回からこちらを利用）

理由としては複数のURLをモック化する場合、こちらのほうが扱いやすい為。

# レビュアーに重点的にチェックして欲しい点

特になし（APIも出来たし、このPRがOKならアップロード機能をとりあえず本番リリース出来るかなと思ってる:cat2:）

# 補足情報

特になし