### PR TITLE
Next.jsの設定ファイル周りのアップデート

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  images: {
-    domains: ['lgtm-images.lgtmeow.com', 'stg-lgtm-images.lgtmeow.com'],
-  },
-};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  images: {
+    domains: ['lgtm-images.lgtmeow.com', 'stg-lgtm-images.lgtmeow.com'],
+  },
+  swcMinify: true,
+};
+
+export default nextConfig;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/138

# 関連 URL

なし

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/138 のDoneの定義を満たしている事

# スクリーンショット

なし

# 変更点概要

以下の通り。

- https://nextjs.org/docs/api-reference/next.config.js/introduction の通り next.config を ESModule形式に変更
- https://nextjs.org/docs/advanced-features/compiler の通り swcMinify が有効に設定

`swcMinify` によってBuild時間の短縮、`next.config` をESModuleにして `@type {import('next').NextConfig}` を追加する事で型定義が有効になった。（ちなみにこのファイルをTypeScriptにする事は出来ない模様）

# レビュアーに重点的にチェックして欲しい点

公式の通りに変更しただけだけど、一応設定内容を時間ある時に確認してもらえると:pray:

# 補足情報

このPRは https://github.com/nekochans/lgtm-cat-frontend/pull/136 に依存している。

https://nextjs.org/docs/advanced-features/compiler のJestの設定も試してみたが、上手く動作しなかったので、とりあえずそのままにしてある。