### PR TITLE
Storybookをデプロイする為にchromaticを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           npm run build
           npm run lint
           npm run test:ci
-          npm run build:storybook
+          npm run build-storybook
         env:
           COGNITO_TOKEN_ENDPOINT: ${{ secrets.COGNITO_TOKEN_ENDPOINT }}
           LGTMEOW_API_URL: ${{ secrets.LGTMEOW_API_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 .vercel
 
 .idea
+
+# Storybook
+storybook-static
+build-storybook.log

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ LGTMEOW_API_URL=https://github.com/nekochans/lgtm-cat-api が稼働しているU
 ```
 export COGNITO_TOKEN_ENDPOINT=https://{CognitoUserPoolのドメイン名}.auth.ap-northeast-1.amazoncognito.com/oauth2/token
 export LGTMEOW_API_URL=https://github.com/nekochans/lgtm-cat-api が稼働しているURLを指定
+export CHROMATIC_PROJECT_TOKEN=Chromaticのトークンを指定
 ```
 
 なくてもテストが通りますが、Mock Service Worker に渡す URL が `undefined` になる為、Mock 周りで何かトラブルがあった際にデバッグの妨げになる可能性があるので設定しておくのが無難です。
+
+`CHROMATIC_PROJECT_TOKEN` に関しては `npm run chromatic` を利用しない限りは設定不要です。
 
 ## 依存 package のインストールと開発用アプリケーションサーバーの起動
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/stylelint": "^13.13.2",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
         "@typescript-eslint/parser": "^5.10.0",
+        "chromatic": "^6.5.2",
         "css-loader": "^5.2.7",
         "eslint": "^8.7.0",
         "eslint-config-next": "^12.0.8",
@@ -11159,6 +11160,17 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.5.2.tgz",
+      "integrity": "sha512-TiAJAF2we4BUflKEfiXs2CiBFvW6yNWkiXKIuBtlSLl2fj1cuueXlV5dYVVoyMDfzTX5JdEn/Bd5CVlpKCeY6A==",
+      "dev": true,
+      "bin": {
+        "chroma": "bin/main.cjs",
+        "chromatic": "bin/main.cjs",
+        "chromatic-cli": "bin/main.cjs"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -41768,6 +41780,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
+    },
+    "chromatic": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-6.5.2.tgz",
+      "integrity": "sha512-TiAJAF2we4BUflKEfiXs2CiBFvW6yNWkiXKIuBtlSLl2fj1cuueXlV5dYVVoyMDfzTX5JdEn/Bd5CVlpKCeY6A==",
       "dev": true
     },
     "chrome-trace-event": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/stylelint": "^13.13.2",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
+    "chromatic": "^6.5.2",
     "css-loader": "^5.2.7",
     "eslint": "^8.7.0",
     "eslint-config-next": "^12.0.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:coverage": "jest --collect-coverage",
     "test:ci": "jest --runInBand --collect-coverage",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build:storybook": "build-storybook -o build/storybook"
+    "build-storybook": "build-storybook -s public"
   },
   "dependencies": {
     "bulma": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:coverage": "jest --collect-coverage",
     "test:ci": "jest --runInBand --collect-coverage",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build-storybook": "build-storybook -s public"
+    "build-storybook": "build-storybook -s public",
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
     "bulma": "^0.9.3",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/126

# 関連 URL

- https://www.chromatic.com/build?appId=622b6c5dc31e9e003a111eb5&number=6
- https://622b6c5dc31e9e003a111eb5-pxkombruwm.chromatic.com/?path=/story/src-components-catimageuploadform-tsx--upload-will-be-successful

# Done の定義

- BuildされたStorybookが

# スクリーンショット

![ViewStorybook](https://user-images.githubusercontent.com/11032365/158040689-a5471ac6-5734-427a-8505-0cf12eefedd9.png)

# 変更点概要

https://www.chromatic.com を利用してPR時にStorybookをデプロイ出来るように設定を追加。

# レビュアーに重点的にチェックして欲しい点

インラインコメント確認してもらえると:pray:

# 補足情報

インラインコメントを参照。

https://storybook.js.org/tutorials/intro-to-storybook/react/ja/deploy に載っている自動デプロイを試す予定、ここまで確認しなとあまり意味がない為、本PRは先にマージしてレビューの指摘があれば別PRで対応という形を取る。