### PR TITLE
chromaticにデプロイを行う為のWorkflowを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,9 @@ on: push
 
 jobs:
   chromatic-deployment:
+    name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,18 +6,14 @@ jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
     steps:
-        # 👇 Version 2 of the action
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0 # 👈 Required to retrieve git history
+          fetch-depth: 0
       - name: Install dependencies
         run: npm ci
-        # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v1
-        # Options required to the GitHub Chromatic Action
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,23 @@
+name: chromatic
+
+on: push
+
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+        # 👇 Version 2 of the action
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # 👈 Required to retrieve git history
+      - name: Install dependencies
+        run: npm ci
+        # 👇 Adds Chromatic as a step in the workflow
+      - name: Publish to Chromatic
+        uses: chromaui/action@v1
+        # Options required to the GitHub Chromatic Action
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![ci](https://github.com/nekochans/lgtm-cat-frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-frontend/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/nekochans/lgtm-cat-frontend/badge.svg?branch=main)](https://coveralls.io/github/nekochans/lgtm-cat-frontend?branch=main)
+[![chromatic](https://github.com/nekochans/lgtm-cat-frontend/actions/workflows/chromatic.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-frontend/actions/workflows/chromatic.yml)
 
 lgtm-cat（サービス名 LGTMeow https://lgtmeow.com のフロントエンド用プロジェクトです。
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/126

# 関連 URL

なし

# Done の定義

- ソースコードに変更があった場合にchromaticに最新のStorybookがデプロイされるようになっている事

# スクリーンショット

## Storybook PublishからStorybookへ遷移出来る、UI Testsから UI reviewへのリンクに遷移出来る

![GitHubActions](https://user-images.githubusercontent.com/11032365/158042886-9aafa5f4-0106-40ba-9060-4d5047dd7944.png)

# 変更点概要

https://www.chromatic.com/docs/github-actions の公式情報を参考にchromaticにStorybookをデプロイする為のWorkflowを追加。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

https://github.com/nekochans/lgtm-cat-frontend/pull/147 の続き。

性質的に先に `main` にマージしないと機能を利用出来ないので、レビューコメントは後で受け付ける事にする。