### PR TITLE
アクセストークン発行用のエンドポイントを作成

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -10,6 +10,7 @@ export const urlList = {
 } as const;
 
 export const apiList = {
+  issueClientCredentialsAccessToken: '/api/oidc/token/access',
   fetchLgtmImages: '/api/lgtm/images',
   uploadCatImage: '/api/lgtm/images',
 };

--- a/src/pages/api/oidc/token.ts
+++ b/src/pages/api/oidc/token.ts
@@ -3,13 +3,13 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import {
   HttpStatusCode,
   httpStatusCode,
-} from '../../../../constants/httpStatusCode';
+} from '../../../constants/httpStatusCode';
 import {
   cognitoClientId,
   cognitoClientSecret,
-} from '../../../../constants/secret';
-import { cognitoTokenEndpointUrl } from '../../../../constants/url';
-import { AccessToken } from '../../../../domain/types/authToken';
+} from '../../../constants/secret';
+import { cognitoTokenEndpointUrl } from '../../../constants/url';
+import { AccessToken } from '../../../domain/types/authToken';
 
 type CognitoTokenResponseBody = {
   // eslint-disable-next-line camelcase

--- a/src/pages/api/oidc/token/access.ts
+++ b/src/pages/api/oidc/token/access.ts
@@ -1,0 +1,100 @@
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+import {
+  HttpStatusCode,
+  httpStatusCode,
+} from '../../../../constants/httpStatusCode';
+import {
+  cognitoClientId,
+  cognitoClientSecret,
+} from '../../../../constants/secret';
+import { cognitoTokenEndpointUrl } from '../../../../constants/url';
+import { AccessToken } from '../../../../domain/types/authToken';
+
+type CognitoTokenResponseBody = {
+  // eslint-disable-next-line camelcase
+  access_token: string;
+  // eslint-disable-next-line camelcase
+  expires_in: number;
+  // eslint-disable-next-line camelcase
+  token_type: 'Bearer';
+};
+
+export type IssueClientCredentialsAccessTokenResponse = AccessToken;
+
+export type IssueClientCredentialsAccessTokenErrorResponse = {
+  error?: {
+    code: HttpStatusCode;
+    message: string;
+  };
+};
+
+const methodNotAllowedErrorResponse = (
+  res: NextApiResponse<
+    | IssueClientCredentialsAccessTokenResponse
+    | IssueClientCredentialsAccessTokenErrorResponse
+  >,
+) =>
+  res.status(httpStatusCode.methodNotAllowed).json({
+    error: {
+      code: httpStatusCode.methodNotAllowed,
+      message: 'Method Not Allowed',
+    },
+  });
+
+const issueClientCredentialsAccessToken = async (
+  res: NextApiResponse<
+    | IssueClientCredentialsAccessTokenResponse
+    | IssueClientCredentialsAccessTokenErrorResponse
+  >,
+) => {
+  const authorization = Buffer.from(
+    `${cognitoClientId()}:${cognitoClientSecret()}`,
+  ).toString('base64');
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${authorization}`,
+    },
+    body: 'grant_type=client_credentials&scope=api.lgtmeow/all',
+  };
+
+  const response = await fetch(cognitoTokenEndpointUrl(), options);
+  if (!response.ok) {
+    return res.status(httpStatusCode.internalServerError).json({
+      error: {
+        code: httpStatusCode.internalServerError,
+        message: 'Internal Server Error',
+      },
+    });
+  }
+
+  const responseBody = (await response.json()) as CognitoTokenResponseBody;
+
+  return res.status(httpStatusCode.ok).json({
+    jwtString: responseBody.access_token,
+  });
+};
+
+const handler: NextApiHandler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<
+    | IssueClientCredentialsAccessTokenResponse
+    | IssueClientCredentialsAccessTokenErrorResponse
+  >,
+): Promise<void> => {
+  switch (req.method) {
+    case 'POST': {
+      const response = await issueClientCredentialsAccessToken(res);
+
+      return response;
+    }
+    default: {
+      return methodNotAllowedErrorResponse(res);
+    }
+  }
+};
+
+export default handler;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/146

# 関連 URL

- `/api/oidc/token/access`

# Done の定義

アクセストークン発行用のエンドポイントが作成されている事。

# スクリーンショット

なし

# 変更点概要

`/oidc/token/access` でアクセストークン発行用のエンドポイントを実装。

https://github.com/nekochans/lgtm-cat-frontend/issues/146#issuecomment-1077693898 のコメントに書かれている「APIルートにアクセストークン取得用のエンドポイントを実装」の対応。

## リクエスト

```
curl -v -X POST http://localhost:2222/api/oidc/token/access | jq
```

## レスポンス

```
{
  "jwtString": "JWT形式のトークン"
}
```

# レビュアーに重点的にチェックして欲しい点

APIのエンドポイント名 `/api/oidc/token/access` の他に良い案があれば意見もらえると:pray:

他のサービスを見るとアクセストークンエンドポイントは単数形が多かった↓

- `/oauth2/token` （Cognito）
- https://github.com/login/oauth/access_token （GItHub）

ちなみに `OIDC` はOpenID Connect (OIDC) の略🐱

https://www.ibm.com/docs/ja/sva/9.0.6?topic=methods-openid-connect-oidc-authentication

# 補足情報

残りの対応は https://github.com/nekochans/lgtm-cat-frontend/issues/146#issuecomment-1077693898 のコメントを参照。

以下の2つは別のPRで対応。

- アップロードAPIへのアクセスをAPI Gatewayに直接行うように変更する
- フロント側で画像ファイルのサイズが一定以上の場合はエラーを表示するように変更する