### PR TITLE
大きな画像がアップロードされた場合にちゃんとエラーを表示させるように改修

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "bulma": "^0.9.3",
         "clipboard": "^2.0.8",
-        "extensible-custom-error": "^0.0.7",
         "lodash.throttle": "^4.1.1",
         "next": "^12.0.3",
         "react": "^17.0.2",
@@ -14753,11 +14752,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/extensible-custom-error": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/extensible-custom-error/-/extensible-custom-error-0.0.7.tgz",
-      "integrity": "sha512-1tgubPkgC+Qi2nUpulI7hGddHh0fA8hXu3P0LBUq2pamZL52KSJZqMu8Q3CiA6kf7Irn/CU1fJe6y4igHCwu4Q=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -44613,11 +44607,6 @@
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
       }
-    },
-    "extensible-custom-error": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/extensible-custom-error/-/extensible-custom-error-0.0.7.tgz",
-      "integrity": "sha512-1tgubPkgC+Qi2nUpulI7hGddHh0fA8hXu3P0LBUq2pamZL52KSJZqMu8Q3CiA6kf7Irn/CU1fJe6y4igHCwu4Q=="
     },
     "external-editor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "bulma": "^0.9.3",
     "clipboard": "^2.0.8",
-    "extensible-custom-error": "^0.0.7",
     "lodash.throttle": "^4.1.1",
     "next": "^12.0.3",
     "react": "^17.0.2",

--- a/src/README.md
+++ b/src/README.md
@@ -50,7 +50,7 @@ Markdown 形式で管理したいドキュメントを格納します。
 
 ビジネス上意味のあるエラーオブジェクトを定義します。
 
-TypeScript の汎用エラーは使わずに、`extensible-custom-error` 利用して何のエラーなのか分かりやすい名前をつけます。
+TypeScript の汎用エラーは使わずに何のエラーなのか分かりやすい名前をつけます。
 
 ### domain/repositories
 

--- a/src/README.md
+++ b/src/README.md
@@ -110,7 +110,7 @@ Next.js に依存する処理以外は極力書かずに、その他の層に処
 
 Redux などの状態管理ライブラリに依存する関数群が実装されます。
 
-現状は ReactContext を使った State 管理用の関数群が格納されています。
+現状は [Valtio](https://github.com/pmndrs/valtio) を使った State 管理用の関数群が格納されています。
 
 ## その他
 

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -2,6 +2,8 @@
 // TODO https://github.com/nekochans/lgtm-cat-frontend/issues/107 を実施する際にファイル先頭のESLintの制御コメントを削除する
 import React, { useState, ChangeEvent } from 'react';
 
+import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSizeTooLargeError';
+import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';
 import {
   AcceptedTypesImageExtension,
   UploadCatImage,
@@ -99,19 +101,15 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   };
 
   const createDisplayErrorMessage = (error: Error) => {
-    const errorName = error.name;
-
-    console.log(errorName);
-
-    // TODO errorNameを型安全に取り出せるようにリファクタリングする
-    switch (errorName) {
-      case 'UploadCatImageSizeTooLargeError':
-        return '画像サイズが大きすぎます。お手数ですが4MB以下の画像を利用して下さい。';
-      case 'UploadCatImageValidationError':
-        return '画像フォーマットが不正です。お手数ですが別の画像を利用して下さい。';
-      default:
-        return 'アップロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
+    if (error instanceof UploadCatImageSizeTooLargeError) {
+      return '画像サイズが大きすぎます。お手数ですが4MB以下の画像を利用して下さい。';
     }
+
+    if (error instanceof UploadCatImageValidationError) {
+      return '画像フォーマットが不正です。お手数ですが別の画像を利用して下さい。';
+    }
+
+    return 'アップロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
   };
 
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -140,8 +138,6 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       image: base64Image,
       imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
     });
-
-    console.log(uploadCatResult.value);
 
     if (isSuccessResult(uploadCatResult)) {
       setUploaded(true);

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -104,7 +104,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     // TODO errorNameを型安全に取り出せるようにリファクタリングする
     switch (errorName) {
       case 'UploadCatImageSizeTooLargeError':
-        return '画像サイズが大きすぎます。お手数ですが2MB以下の画像を利用して下さい。';
+        return '画像サイズが大きすぎます。お手数ですが4MB以下の画像を利用して下さい。';
       case 'UploadCatImageValidationError':
         return '画像フォーマットが不正です。お手数ですが別の画像を利用して下さい。';
       default:

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -101,6 +101,8 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
   const createDisplayErrorMessage = (error: Error) => {
     const errorName = error.name;
 
+    console.log(errorName);
+
     // TODO errorNameを型安全に取り出せるようにリファクタリングする
     switch (errorName) {
       case 'UploadCatImageSizeTooLargeError':

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -141,6 +141,8 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
     });
 
+    console.log(uploadCatResult.value);
+
     if (isSuccessResult(uploadCatResult)) {
       setUploaded(true);
       setErrorMessage('');

--- a/src/domain/errors/FetchLgtmImagesInRandomAuthError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRandomAuthError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class FetchLgtmImagesInRandomAuthError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class FetchLgtmImagesInRandomAuthError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/FetchLgtmImagesInRandomError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRandomError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class FetchLgtmImagesInRandomError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class FetchLgtmImagesInRandomError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/IssueAccessTokenError.ts
+++ b/src/domain/errors/IssueAccessTokenError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class IssueAccessTokenError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class IssueAccessTokenError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/UploadCatImageAuthError.ts
+++ b/src/domain/errors/UploadCatImageAuthError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class UploadCatImageAuthError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class UploadCatImageAuthError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/UploadCatImageSizeTooLargeError.ts
+++ b/src/domain/errors/UploadCatImageSizeTooLargeError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class UploadCatImageSizeTooLargeError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class UploadCatImageSizeTooLargeError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/UploadCatImageUnexpectedError.ts
+++ b/src/domain/errors/UploadCatImageUnexpectedError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class UploadCatImageUnexpectedError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class UploadCatImageUnexpectedError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/UploadCatImageValidationError.ts
+++ b/src/domain/errors/UploadCatImageValidationError.ts
@@ -1,3 +1,10 @@
-import ExtensibleCustomError from 'extensible-custom-error';
+export default class UploadCatImageValidationError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
 
-export default class UploadCatImageValidationError extends ExtensibleCustomError {}
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
@@ -33,10 +33,8 @@ export const issueAccessToken: IssueAccessToken = async () => {
     // TODO このブロックに入った時は原因不明なエラーなのでSlack等に通知を送信したい
     const newError =
       error instanceof Error
-        ? new IssueAccessTokenError(error)
-        : new IssueAccessTokenError(
-            new Error('issueAccessToken Unexpected error'),
-          );
+        ? new IssueAccessTokenError(error.message)
+        : new IssueAccessTokenError('issueAccessToken Unexpected error');
 
     return createFailureResult<IssueAccessTokenError>(newError);
   }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/146

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue146fix-erro-46ed27-nekochans.vercel.app/upload

# Done の定義

- 大きな画像がアップロードされた場合にちゃんとエラーメッセージが表示されるようになっている事

https://github.com/nekochans/lgtm-cat-frontend/issues/146#issuecomment-1077693898 の「フロント側で画像ファイルのサイズが一定以上の場合はエラーを表示するように変更する」の対応。

# スクリーンショット

## 大きな画像を選択したときのエラー表示

![1](https://user-images.githubusercontent.com/11032365/162463160-ff0fa255-541e-421a-8cd3-d1f09d7c4889.png)

![2](https://user-images.githubusercontent.com/11032365/162463353-6eccebf2-f634-48c7-8bac-0d5c992711bd.png)

![3](https://user-images.githubusercontent.com/11032365/162463404-2a633250-d1ee-42d4-8ea9-7b7f418485ab.png)

# 変更点概要

まず大きな画像がアップロードされた際にローディング中のまま固まってしまう原因だが、原因は `extensible-custom-error` を継承したカスタムエラーを利用した際に以下のようなエラーが発生してしまっていた為。

```
UploadCatImageSizeTooLargeError.ts?7306:3 Uncaught (in promise) TypeError: Class constructor ExtensibleCustomError cannot be invoked without 'new'
    at new UploadCatImageSizeTooLargeError (UploadCatImageSizeTooLargeError.ts?7306:3:53)
    at _callee$ (imageRepository.ts?e6c7:73:11)
    at tryCatch (runtime.js?2d8a:45:16)
    at Generator.invoke [as _invoke] (runtime.js?2d8a:274:1)
    at Generator.prototype.<computed> [as next] (runtime.js?2d8a:97:1)
    at asyncGeneratorStep (imageRepository.ts?e6c7:19:58)
    at _next (imageRepository.ts?e6c7:19:58)
```

この現象は `tsconfig.json` の compilerOptions の targetをes5からes2015などに変更すれば解消出来るハズだが、それを行っても問題は解決しなかった。おそらく `extensible-custom-error` 内で利用されている構文が原因だと思われる。

`extensible-custom-error` を利用しなくてもエラーの発生箇所は分かるので、https://www.memory-lovers.blog/entry/2021/01/18/022021 を参考に標準のErrorを拡張する形で再実装を行う形にした。

この変更を行う事で問題なくエラーメッセージが表示されるようになった。

API Gatewayは10MBのPayloadまで受け取れるハズだが実際には4.8MBの画像だとアウト（API GatewayからHTTPステータス 413が返ってくる）4.2MBの画像だとセーフだった。

Next.jsのAPIルートを利用していた時は3MBくらいの画像でもダメだったのでアップロード可能な画像サイズは以前よりも確実に増えている。

その為エラーメッセージも `画像サイズが大きすぎます。お手数ですが4MB以下の画像を利用して下さい。` に変更した。

# レビュアーに重点的にチェックして欲しい点

対応方針が問題ないか確認してもらえると:pray:

# 補足情報
なし