### PR TITLE
新しく登録されたねこ画像を表示させるButtonを追加

### DIFF
--- a/src/__tests__/pages/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.spec.tsx.snap
@@ -84,7 +84,7 @@ exports[`IndexPage Snapshot test 1`] = `
                     style="margin: 0.5rem 0.75rem;"
                     type="submit"
                   >
-                    新しい猫ちゃんを表示
+                    新着の猫ちゃんを表示
                   </button>
                 </div>
               </div>

--- a/src/__tests__/pages/__snapshots__/index.spec.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/index.spec.tsx.snap
@@ -79,6 +79,13 @@ exports[`IndexPage Snapshot test 1`] = `
                   >
                     他の猫ちゃんを表示
                   </button>
+                  <button
+                    class="button is-outlined"
+                    style="margin: 0.5rem 0.75rem;"
+                    type="submit"
+                  >
+                    新しい猫ちゃんを表示
+                  </button>
                 </div>
               </div>
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import RandomButtonContainer from '../containers/RandomButton';
+import RecentlyCatFetchButtonContainer from '../containers/RecentlyCatFetchButtonContainer';
 
 import ServiceDescription from './ServiceDescription';
 
@@ -56,6 +57,7 @@ const Header: React.FC<Props> = ({ topLink, uploadLink }: Props) => {
                 <div className="buttons">
                   {uploadLink}
                   <RandomButtonContainer />
+                  <RecentlyCatFetchButtonContainer />
                 </div>
               </div>
             </div>

--- a/src/components/RecentlyCatFetchButton.stories.tsx
+++ b/src/components/RecentlyCatFetchButton.stories.tsx
@@ -11,7 +11,7 @@ type Story = ComponentStoryObj<typeof RecentlyCatFetchButton>;
 
 const props = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClick: (): void => {},
+  handleOnClick: (): void => {},
 };
 
 export const Default: Story = {

--- a/src/components/RecentlyCatFetchButton.stories.tsx
+++ b/src/components/RecentlyCatFetchButton.stories.tsx
@@ -1,0 +1,19 @@
+import RecentlyCatFetchButton from './RecentlyCatFetchButton';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/RecentlyCatFetchButton.tsx',
+  component: RecentlyCatFetchButton,
+} as Meta<typeof RecentlyCatFetchButton>;
+
+type Story = ComponentStoryObj<typeof RecentlyCatFetchButton>;
+
+const props = {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onClick: (): void => {},
+};
+
+export const Default: Story = {
+  args: props,
+};

--- a/src/components/RecentlyCatFetchButton.tsx
+++ b/src/components/RecentlyCatFetchButton.tsx
@@ -1,15 +1,15 @@
 import type { VFC } from 'react';
 
 type Props = {
-  onClick: () => void;
+  handleOnClick: () => void;
 };
 
-const RecentlyCatFetchButton: VFC<Props> = ({ onClick }) => (
+const RecentlyCatFetchButton: VFC<Props> = ({ handleOnClick }) => (
   <button
     className="button is-outlined"
     style={{ margin: '0.5rem 0.75rem' }}
     type="submit"
-    onClick={() => onClick()}
+    onClick={() => handleOnClick()}
   >
     新しい猫ちゃんを表示
   </button>

--- a/src/components/RecentlyCatFetchButton.tsx
+++ b/src/components/RecentlyCatFetchButton.tsx
@@ -1,10 +1,10 @@
-import type { VFC } from 'react';
+import React from 'react';
 
 type Props = {
   handleOnClick: () => void;
 };
 
-const RecentlyCatFetchButton: VFC<Props> = ({ handleOnClick }) => (
+const RecentlyCatFetchButton: React.VFC<Props> = ({ handleOnClick }) => (
   <button
     className="button is-outlined"
     style={{ margin: '0.5rem 0.75rem' }}

--- a/src/components/RecentlyCatFetchButton.tsx
+++ b/src/components/RecentlyCatFetchButton.tsx
@@ -11,7 +11,7 @@ const RecentlyCatFetchButton: React.VFC<Props> = ({ handleOnClick }) => (
     type="submit"
     onClick={() => handleOnClick()}
   >
-    新しい猫ちゃんを表示
+    新着の猫ちゃんを表示
   </button>
 );
 

--- a/src/components/RecentlyCatFetchButton.tsx
+++ b/src/components/RecentlyCatFetchButton.tsx
@@ -1,0 +1,18 @@
+import type { VFC } from 'react';
+
+type Props = {
+  onClick: () => void;
+};
+
+const RecentlyCatFetchButton: VFC<Props> = ({ onClick }) => (
+  <button
+    className="button is-outlined"
+    style={{ margin: '0.5rem 0.75rem' }}
+    type="submit"
+    onClick={() => onClick()}
+  >
+    新しい猫ちゃんを表示
+  </button>
+);
+
+export default RecentlyCatFetchButton;

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -40,3 +40,7 @@ export const uploadCatImageUrl = (): string => `${lgtmeowApiUrl()}/lgtm-images`;
 // この関数はサーバーサイドでしか動作しない
 export const fetchLgtmImagesUrl = (): string =>
   `${lgtmeowApiUrl()}/lgtm-images`;
+
+// この関数はサーバーサイドでしか動作しない
+export const fetchLgtmImagesInRecentlyCreatedUrl = (): string =>
+  `${lgtmeowApiUrl()}/lgtm-images/recently-created`;

--- a/src/containers/RecentlyCatFetchButtonContainer.tsx
+++ b/src/containers/RecentlyCatFetchButtonContainer.tsx
@@ -5,7 +5,7 @@ import RecentlyCatFetchButton from '../components/RecentlyCatFetchButton';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import { issueAccessToken } from '../infrastructures/repositories/api/fetch/authTokenRepository';
 import { fetchLgtmImagesInRecentlyCreated } from '../infrastructures/repositories/api/fetch/imageRepository';
-import { sendFetchRandomImages } from '../infrastructures/utils/gtm';
+import { sendFetchRecentlyCreatedImages } from '../infrastructures/utils/gtm';
 import {
   updateIsFailedFetchLgtmImages,
   updateLgtmImages,
@@ -34,7 +34,7 @@ const RecentlyCatFetchButtonContainer: VFC = () => {
 
     updateLgtmImages(lgtmImagesResponse.value.lgtmImages);
     updateIsFailedFetchLgtmImages(false);
-    sendFetchRandomImages('fetch_random_images_button');
+    sendFetchRecentlyCreatedImages('fetch_recently_created_images_button');
   };
 
   const limitThreshold = 500;

--- a/src/containers/RecentlyCatFetchButtonContainer.tsx
+++ b/src/containers/RecentlyCatFetchButtonContainer.tsx
@@ -1,0 +1,50 @@
+import throttle from 'lodash/throttle';
+
+import RecentlyCatFetchButton from '../components/RecentlyCatFetchButton';
+import { isSuccessResult } from '../domain/repositories/repositoryResult';
+import { issueAccessToken } from '../infrastructures/repositories/api/fetch/authTokenRepository';
+import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
+import { sendFetchRandomImages } from '../infrastructures/utils/gtm';
+import {
+  updateIsFailedFetchLgtmImages,
+  updateLgtmImages,
+} from '../stores/valtio/lgtmImages';
+
+import type { VFC } from 'react';
+
+const RecentlyCatFetchButtonContainer: VFC = () => {
+  const handleOnClick = async () => {
+    const issueAccessTokenResult = await issueAccessToken();
+    if (!isSuccessResult(issueAccessTokenResult)) {
+      updateLgtmImages([]);
+      updateIsFailedFetchLgtmImages(true);
+
+      return;
+    }
+
+    const lgtmImagesResponse = await fetchLgtmImagesInRandom({
+      accessToken: { jwtString: issueAccessTokenResult.value.jwtString },
+    });
+
+    if (!isSuccessResult(lgtmImagesResponse)) {
+      updateLgtmImages([]);
+      updateIsFailedFetchLgtmImages(true);
+
+      return;
+    }
+
+    updateLgtmImages(lgtmImagesResponse.value.lgtmImages);
+    updateIsFailedFetchLgtmImages(false);
+    sendFetchRandomImages('fetch_random_images_button');
+  };
+
+  const limitThreshold = 500;
+  const handleOnClickThrottled = throttle(
+    () => handleOnClick(),
+    limitThreshold,
+  );
+
+  return <RecentlyCatFetchButton handleOnClick={handleOnClickThrottled} />;
+};
+
+export default RecentlyCatFetchButtonContainer;

--- a/src/containers/RecentlyCatFetchButtonContainer.tsx
+++ b/src/containers/RecentlyCatFetchButtonContainer.tsx
@@ -1,4 +1,5 @@
 import throttle from 'lodash/throttle';
+import React, { VFC } from 'react';
 
 import RecentlyCatFetchButton from '../components/RecentlyCatFetchButton';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
@@ -9,8 +10,6 @@ import {
   updateIsFailedFetchLgtmImages,
   updateLgtmImages,
 } from '../stores/valtio/lgtmImages';
-
-import type { VFC } from 'react';
 
 const RecentlyCatFetchButtonContainer: VFC = () => {
   const handleOnClick = async () => {

--- a/src/containers/RecentlyCatFetchButtonContainer.tsx
+++ b/src/containers/RecentlyCatFetchButtonContainer.tsx
@@ -4,7 +4,7 @@ import React, { VFC } from 'react';
 import RecentlyCatFetchButton from '../components/RecentlyCatFetchButton';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import { issueAccessToken } from '../infrastructures/repositories/api/fetch/authTokenRepository';
-import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
+import { fetchLgtmImagesInRecentlyCreated } from '../infrastructures/repositories/api/fetch/imageRepository';
 import { sendFetchRandomImages } from '../infrastructures/utils/gtm';
 import {
   updateIsFailedFetchLgtmImages,
@@ -21,7 +21,7 @@ const RecentlyCatFetchButtonContainer: VFC = () => {
       return;
     }
 
-    const lgtmImagesResponse = await fetchLgtmImagesInRandom({
+    const lgtmImagesResponse = await fetchLgtmImagesInRecentlyCreated({
       accessToken: { jwtString: issueAccessTokenResult.value.jwtString },
     });
 

--- a/src/domain/errors/FetchLgtmImagesInRecentlyCreatedAuthError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRecentlyCreatedAuthError.ts
@@ -1,0 +1,10 @@
+export default class FetchLgtmImagesInRecentlyCreatedAuthError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/FetchLgtmImagesInRecentlyCreatedError.ts
+++ b/src/domain/errors/FetchLgtmImagesInRecentlyCreatedError.ts
@@ -1,0 +1,10 @@
+export default class FetchLgtmImagesInRecentlyCreatedError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,4 +1,5 @@
 import FetchLgtmImagesInRandomError from '../errors/FetchLgtmImagesInRandomError';
+import FetchLgtmImagesInRecentlyCreatedAuthError from '../errors/FetchLgtmImagesInRecentlyCreatedAuthError';
 import FetchLgtmImagesInRecentlyCreatedError from '../errors/FetchLgtmImagesInRecentlyCreatedError';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
@@ -20,7 +21,11 @@ export type FetchLgtmImagesInRandom = (
 export type FetchLgtmImagesInRecentlyCreated = (
   request: FetchLgtmImagesRequest,
 ) => Promise<
-  RepositoryResult<LgtmImages, FetchLgtmImagesInRecentlyCreatedError>
+  RepositoryResult<
+    LgtmImages,
+    | FetchLgtmImagesInRecentlyCreatedAuthError
+    | FetchLgtmImagesInRecentlyCreatedError
+  >
 >;
 
 export type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,4 +1,5 @@
 import FetchLgtmImagesInRandomError from '../errors/FetchLgtmImagesInRandomError';
+import FetchLgtmImagesInRecentlyCreatedError from '../errors/FetchLgtmImagesInRecentlyCreatedError';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
@@ -15,6 +16,12 @@ export type FetchLgtmImagesRequest = {
 export type FetchLgtmImagesInRandom = (
   request: FetchLgtmImagesRequest,
 ) => Promise<RepositoryResult<LgtmImages, FetchLgtmImagesInRandomError>>;
+
+export type FetchLgtmImagesInRecentlyCreated = (
+  request: FetchLgtmImagesRequest,
+) => Promise<
+  RepositoryResult<LgtmImages, FetchLgtmImagesInRecentlyCreatedError>
+>;
 
 export type AcceptedTypesImageExtension = '.png' | '.jpg' | '.jpeg';
 

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -1,16 +1,20 @@
 import { httpStatusCode } from '../../../../constants/httpStatusCode';
 import {
+  fetchLgtmImagesInRecentlyCreatedUrl,
   fetchLgtmImagesUrl,
   uploadCatImageUrl,
 } from '../../../../constants/url';
 import FetchLgtmImagesInRandomAuthError from '../../../../domain/errors/FetchLgtmImagesInRandomAuthError';
 import FetchLgtmImagesInRandomError from '../../../../domain/errors/FetchLgtmImagesInRandomError';
+import FetchLgtmImagesInRecentlyCreatedAuthError from '../../../../domain/errors/FetchLgtmImagesInRecentlyCreatedAuthError';
+import FetchLgtmImagesInRecentlyCreatedError from '../../../../domain/errors/FetchLgtmImagesInRecentlyCreatedError';
 import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
 import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import {
   FetchLgtmImagesInRandom,
+  FetchLgtmImagesInRecentlyCreated,
   UploadCatImage,
 } from '../../../../domain/repositories/imageRepository';
 import {
@@ -44,6 +48,36 @@ export const fetchLgtmImagesInRandom: FetchLgtmImagesInRandom = async (
 
   return createSuccessResult<LgtmImages>(lgtmImages);
 };
+
+export const fetchLgtmImagesInRecentlyCreated: FetchLgtmImagesInRecentlyCreated =
+  async (request) => {
+    const options: RequestInit = {
+      method: 'GET',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        Authorization: `Bearer ${request.accessToken.jwtString}`,
+      },
+    };
+
+    const response = await fetch(
+      fetchLgtmImagesInRecentlyCreatedUrl(),
+      options,
+    );
+    if (!response.ok) {
+      if (response.status === httpStatusCode.unauthorized) {
+        return createFailureResult(
+          new FetchLgtmImagesInRecentlyCreatedAuthError(),
+        );
+      }
+
+      return createFailureResult(new FetchLgtmImagesInRecentlyCreatedError());
+    }
+
+    const lgtmImages = (await response.json()) as LgtmImages;
+
+    return createSuccessResult<LgtmImages>(lgtmImages);
+  };
 
 export const uploadCatImage: UploadCatImage = async (request) => {
   const options: RequestInit = {

--- a/src/infrastructures/utils/gtm.ts
+++ b/src/infrastructures/utils/gtm.ts
@@ -53,6 +53,18 @@ export const sendFetchRandomImages = (
   });
 };
 
+type SendFetchRecentlyCreatedImagesLabel =
+  'fetch_recently_created_images_button';
+
+export const sendFetchRecentlyCreatedImages = (
+  label: SendFetchRecentlyCreatedImagesLabel,
+): void => {
+  window.dataLayer.push({
+    event: 'fetch_recently_created_images',
+    fetch_recently_created_images_trigger: label,
+  });
+};
+
 // ねこ画像がアップロードしLGTM画像を作成する機能が利用された際に実行する
 type SendUploadCatImageLabel = 'upload_cat_image_button';
 


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/132

# 関連 URL

トップページ

# Done の定義

- Headerのメニューに新しく登録されたねこ画像を取得するButtonが追加されている事

# スクリーンショット

## 新しいねこがぞ画像が取得出来ている事を確認

<img width="1224" alt="ss" src="https://user-images.githubusercontent.com/11032365/163581865-9dd79cba-06ac-49b4-a1c6-8c79d52d2029.png">

# 変更点概要

「新しい猫ちゃんを表示」Buttonを追加し最近追加された新しいねこ画像をAPIから取得して表示させる処理を実装。

GTM上にもイベントを送信出来るようにカスタムイベントの設定も追加済。


# レビュアーに重点的にチェックして欲しい点

Buttonの文言が「新しい猫ちゃんを表示」になっているけど、これで問題ないか意見をもらえると:pray:

# 補足情報

実装している時に以下のようなリファクタリング案を思いついたので別issueで対応予定。

- [中でやっている事がほぼ同じなので、RandomButtonとRecentlyCatFetchButtonは共通のComponentとして実装](https://github.com/nekochans/lgtm-cat-frontend/issues/156)
- [ねこ画像を取得する関数のIFはランダム取得と最新画像取得が全く同じなのでIFを統一する](https://github.com/nekochans/lgtm-cat-frontend/issues/157)
