### PR TITLE
画像アップロード前にねこ画像判定APIをコールする処理を追加

### DIFF
--- a/src/components/AfterUploadInfoMessage.stories.tsx
+++ b/src/components/AfterUploadInfoMessage.stories.tsx
@@ -1,0 +1,12 @@
+import AfterUploadInfoMessage from './AfterUploadInfoMessage';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/AfterUploadInfoMessage.tsx',
+  component: AfterUploadInfoMessage,
+} as Meta<typeof AfterUploadInfoMessage>;
+
+type Story = ComponentStoryObj<typeof AfterUploadInfoMessage>;
+
+export const Default: Story = {};

--- a/src/components/AfterUploadInfoMessage.tsx
+++ b/src/components/AfterUploadInfoMessage.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const AfterUploadWarningMessage: React.FC = () => (
-  <article className="message is-warning">
+const AfterUploadInfoMessage: React.FC = () => (
+  <article className="message is-info">
     <div className="message-header">
-      <p>注意 🐱！</p>
+      <p>お知らせ 🐱</p>
     </div>
     <div className="message-body">
       <p>
@@ -13,4 +13,4 @@ const AfterUploadWarningMessage: React.FC = () => (
   </article>
 );
 
-export default AfterUploadWarningMessage;
+export default AfterUploadInfoMessage;

--- a/src/components/AfterUploadWarningMessage.tsx
+++ b/src/components/AfterUploadWarningMessage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-// TODO このComponentは https://github.com/nekochans/lgtm-cat/issues/15 の開発が終了した時点で削除する
 const AfterUploadWarningMessage: React.FC = () => (
   <article className="message is-warning">
     <div className="message-header">
@@ -8,7 +7,7 @@ const AfterUploadWarningMessage: React.FC = () => (
     </div>
     <div className="message-body">
       <p>
-        このモーダルを閉じるとMarkdownソースをコピー出来なくなるのでご注意下さい。
+        このモーダルを閉じてしまった場合はトップページの「新着の猫ちゃんを表示」を押下して探してみてください。
       </p>
     </div>
   </article>

--- a/src/components/AfterUploadWarningMessage.tsx
+++ b/src/components/AfterUploadWarningMessage.tsx
@@ -7,7 +7,7 @@ const AfterUploadWarningMessage: React.FC = () => (
     </div>
     <div className="message-body">
       <p>
-        このモーダルを閉じてしまった場合はトップページの「新着の猫ちゃんを表示」を押下して探してみてください。
+        トップページの「新着の猫ちゃんを表示」からもアップロードした画像を確認できます。
       </p>
     </div>
   </article>

--- a/src/components/CatImageUploadConfirmModal.tsx
+++ b/src/components/CatImageUploadConfirmModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Modal from 'react-modal';
 
-import AfterUploadWarningMessage from './AfterUploadWarningMessage';
+import AfterUploadInfoMessage from './AfterUploadInfoMessage';
 import CatImageUploadSuccessMessage from './CatImageUploadSuccessMessage';
 import CopyMarkdownSourceButton from './CopyMarkdownSourceButton';
 import CreatedLgtmImage from './CreatedLgtmImage';
@@ -64,7 +64,7 @@ const CatImageUploadConfirmModal: React.FC<Props> = ({
             )}
             {isLoading ? <ProgressBar /> : ''}
             {uploaded ? <CatImageUploadSuccessMessage /> : ''}
-            {uploaded ? <AfterUploadWarningMessage /> : ''}
+            {uploaded ? <AfterUploadInfoMessage /> : ''}
             {imagePreviewUrl && !uploaded ? (
               <UploadCatImagePreview imagePreviewUrl={imagePreviewUrl} />
             ) : (

--- a/src/components/CatImageUploadForm.stories.tsx
+++ b/src/components/CatImageUploadForm.stories.tsx
@@ -1,6 +1,11 @@
 import { rest } from 'msw';
 
-import { apiList, appBaseUrl, uploadCatImageUrl } from '../constants/url';
+import {
+  apiList,
+  appBaseUrl,
+  isAcceptableCatImageUrl,
+  uploadCatImageUrl,
+} from '../constants/url';
 import { UploadCatImage } from '../domain/repositories/imageRepository';
 import { createSuccessResult } from '../domain/repositories/repositoryResult';
 import { UploadedImage } from '../domain/types/lgtmImage';
@@ -8,6 +13,12 @@ import { uploadCatImage } from '../infrastructures/repositories/api/fetch/imageR
 import sleep from '../infrastructures/utils/sleep';
 import mockInternalServerError from '../mocks/api/error/mockInternalServerError';
 import mockTokenEndpoint from '../mocks/api/external/cognito/mockTokenEndpoint';
+import mockIsAcceptableCatImage from '../mocks/api/external/recognition/mockIsAcceptableCatImage';
+import mockIsAcceptableCatImageError from '../mocks/api/external/recognition/mockIsAcceptableCatImageError';
+import mockIsAcceptableCatImageNotAllowedImageExtension from '../mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension';
+import mockIsAcceptableCatImageNotCatImage from '../mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage';
+import mockIsAcceptableCatImageNotModerationImage from '../mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage';
+import mockIsAcceptableCatImagePersonFaceInImage from '../mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage';
 import mockUploadCatImage from '../mocks/api/lgtm/images/mockUploadCatImage';
 import mockUploadCatImageAuthError from '../mocks/api/lgtm/images/mockUploadCatImageAuthError';
 import mockUploadCatImagePayloadTooLarge from '../mocks/api/lgtm/images/mockUploadCatImagePayloadTooLarge';
@@ -35,6 +46,7 @@ export const UploadWillBeSuccessful: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
         rest.post(uploadCatImageUrl(), mockUploadCatImage),
       ],
     },
@@ -65,6 +77,7 @@ export const UploadWillBeSuccessfulWithLoadingMessage: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
       ],
     },
   },
@@ -81,6 +94,7 @@ export const UploadingWillResultInAnAuthError: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
         rest.post(uploadCatImageUrl(), mockUploadCatImageAuthError),
       ],
     },
@@ -98,6 +112,7 @@ export const UploadingWillResultInImageSizeTooLargeError: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
         rest.post(uploadCatImageUrl(), mockUploadCatImagePayloadTooLarge),
       ],
     },
@@ -115,6 +130,7 @@ export const UploadingWillResultInValidationError: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
         rest.post(uploadCatImageUrl(), mockUploadCatImageUnprocessableEntity),
       ],
     },
@@ -132,7 +148,105 @@ export const UploadingWillResultInAnUnexpectedError: Story = {
           `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
           mockTokenEndpoint,
         ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
         rest.post(uploadCatImageUrl(), mockInternalServerError),
+      ],
+    },
+  },
+};
+
+export const UploadingWillResultInNotAllowedImageExtensionError: Story = {
+  args: {
+    uploadCatImage,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotAllowedImageExtension,
+        ),
+      ],
+    },
+  },
+};
+
+export const UploadingWillResultInNotModerationImageError: Story = {
+  args: {
+    uploadCatImage,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotModerationImage,
+        ),
+      ],
+    },
+  },
+};
+
+export const UploadingWillResultInPersonFaceInImageError: Story = {
+  args: {
+    uploadCatImage,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImagePersonFaceInImage,
+        ),
+      ],
+    },
+  },
+};
+
+export const UploadingWillResultInNotCatImageError: Story = {
+  args: {
+    uploadCatImage,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(
+          isAcceptableCatImageUrl(),
+          mockIsAcceptableCatImageNotCatImage,
+        ),
+      ],
+    },
+  },
+};
+
+export const UploadingWillResultInAnErrorHasOccurred: Story = {
+  args: {
+    uploadCatImage,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+          mockTokenEndpoint,
+        ),
+        rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImageError),
       ],
     },
   },

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -126,7 +126,7 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
       case 'person face in the image':
         return '申し訳ありませんが人の顔が写っていない画像をご利用ください。';
       case 'not cat image':
-        return '申し訳ありませんがはっきりとねこが写っている画像をご利用ください。';
+        return '申し訳ありませんがはっきりと猫が写っている画像をご利用ください。';
       case 'an error has occurred':
         return '予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
       default:

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -6,10 +6,13 @@ import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSize
 import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';
 import {
   AcceptedTypesImageExtension,
+  IsAcceptableCatImageNotAcceptableReason,
   UploadCatImage,
 } from '../domain/repositories/imageRepository';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import { issueAccessToken } from '../infrastructures/repositories/api/fetch/authTokenRepository';
+import { isAcceptableCatImage } from '../infrastructures/repositories/api/fetch/imageRepository';
+import assertNever from '../infrastructures/utils/assertNever';
 import { sendUploadCatImage } from '../infrastructures/utils/gtm';
 
 import CatImageUploadConfirmModal from './CatImageUploadConfirmModal';
@@ -112,6 +115,25 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     return 'アップロード中に予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
   };
 
+  const createDisplayErrorMessageFromNotAcceptableReason = (
+    notAcceptableReason: IsAcceptableCatImageNotAcceptableReason,
+  ): string => {
+    switch (notAcceptableReason) {
+      case 'not an allowed image extension':
+        return 'png, jpg, jpeg の画像のみアップロード出来ます。';
+      case 'not moderation image':
+        return 'この画像は不適切なものが写っているので利用出来ません。';
+      case 'person face in the image':
+        return '申し訳ありませんが人の顔が写っていない画像をご利用ください。';
+      case 'not cat image':
+        return '申し訳ありませんがはっきりとねこが写っている画像をご利用ください。';
+      case 'an error has occurred':
+        return '予期せぬエラーが発生しました。お手数ですが、しばらく時間が経ってからお試し下さい。';
+      default:
+        return assertNever(notAcceptableReason);
+    }
+  };
+
   const handleOnSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -124,6 +146,40 @@ const CatImageUploadForm: React.FC<Props> = ({ uploadCatImage }) => {
     const accessTokenResult = await issueAccessToken();
     if (!isSuccessResult(accessTokenResult)) {
       setErrorMessage(createDisplayErrorMessage(accessTokenResult.value));
+      setImagePreviewUrl('');
+      setUploadImageExtension('');
+      setCreatedLgtmImageUrl('');
+      setIsLoading(false);
+      closeModal();
+
+      return;
+    }
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage({
+      accessToken: accessTokenResult.value,
+      image: base64Image,
+      imageExtension: uploadImageExtension as AcceptedTypesImageExtension,
+    });
+
+    if (isSuccessResult(isAcceptableCatImageResult)) {
+      if (!isAcceptableCatImageResult.value.isAcceptableCatImage) {
+        setErrorMessage(
+          createDisplayErrorMessageFromNotAcceptableReason(
+            isAcceptableCatImageResult.value.notAcceptableReason,
+          ),
+        );
+        setImagePreviewUrl('');
+        setUploadImageExtension('');
+        setCreatedLgtmImageUrl('');
+        setIsLoading(false);
+        closeModal();
+
+        return;
+      }
+    } else {
+      setErrorMessage(
+        createDisplayErrorMessage(isAcceptableCatImageResult.value),
+      );
       setImagePreviewUrl('');
       setUploadImageExtension('');
       setCreatedLgtmImageUrl('');

--- a/src/components/CatImageUploadSuccessMessage.stories.tsx
+++ b/src/components/CatImageUploadSuccessMessage.stories.tsx
@@ -1,0 +1,12 @@
+import CatImageUploadSuccessMessage from './CatImageUploadSuccessMessage';
+
+import type { ComponentStoryObj, Meta } from '@storybook/react';
+
+export default {
+  title: 'src/components/CatImageUploadSuccessMessage.tsx',
+  component: CatImageUploadSuccessMessage,
+} as Meta<typeof CatImageUploadSuccessMessage>;
+
+type Story = ComponentStoryObj<typeof CatImageUploadSuccessMessage>;
+
+export const Default: Story = {};

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -10,9 +10,6 @@ const CatImageUploadSuccessMessage: React.FC = () => (
       <p>
         「Markdownソースをコピー」ボタンか以下の画像をクリックするとMarkdownソースがコピーされます。
       </p>
-      <p>
-        審査に合格していれば、コピーされたMarkdownソースで生成されたLGTM画像を確認出来ます。
-      </p>
     </div>
   </article>
 );

--- a/src/components/CatImageUploadSuccessMessage.tsx
+++ b/src/components/CatImageUploadSuccessMessage.tsx
@@ -6,7 +6,7 @@ const CatImageUploadSuccessMessage: React.FC = () => (
       <p>アップロードに成功しました🐱！</p>
     </div>
     <div className="message-body">
-      <p>アップロードされた画像を審査していますので、少々お待ち下さい。</p>
+      <p>LGTM画像を作成しているので少々お待ち下さい。</p>
       <p>
         「Markdownソースをコピー」ボタンか以下の画像をクリックするとMarkdownソースがコピーされます。
       </p>

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -44,3 +44,11 @@ export const fetchLgtmImagesUrl = (): string =>
 // この関数はサーバーサイドでしか動作しない
 export const fetchLgtmImagesInRecentlyCreatedUrl = (): string =>
   `${lgtmeowApiUrl()}/lgtm-images/recently-created`;
+
+export const imageRecognitionApiUrl = (): string =>
+  process.env.NEXT_PUBLIC_IMAGE_RECOGNITION_API_URL
+    ? process.env.NEXT_PUBLIC_IMAGE_RECOGNITION_API_URL
+    : '';
+
+export const isAcceptableCatImageUrl = (): string =>
+  `${imageRecognitionApiUrl()}/cat-images/validation-results`;

--- a/src/domain/errors/IsAcceptableCatImageAuthError.ts
+++ b/src/domain/errors/IsAcceptableCatImageAuthError.ts
@@ -1,0 +1,10 @@
+export default class IsAcceptableCatImageAuthError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/errors/IsAcceptableCatImageError.ts
+++ b/src/domain/errors/IsAcceptableCatImageError.ts
@@ -1,0 +1,10 @@
+export default class IsAcceptableCatImageError extends Error {
+  constructor(error?: string) {
+    super(error);
+    this.name = new.target.name;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,5 +1,6 @@
 import FetchLgtmImagesAuthError from '../errors/FetchLgtmImagesAuthError';
 import FetchLgtmImagesError from '../errors/FetchLgtmImagesError';
+import IsAcceptableCatImageError from '../errors/IsAcceptableCatImageError';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../errors/UploadCatImageUnexpectedError';
@@ -37,4 +38,24 @@ export type UploadCatImage = (
     | UploadCatImageValidationError
     | UploadCatImageUnexpectedError
   >
+>;
+
+export type IsAcceptableCatImageRequest = UploadCatImageRequest;
+
+type IsAcceptableCatImageNotAcceptableReason =
+  | 'not an allowed image extension'
+  | 'not moderation image'
+  | 'person face in the image'
+  | 'not cat image'
+  | 'an error has occurred';
+
+export type IsAcceptableCatImageResponse = {
+  isAcceptableCatImage: boolean;
+  notAcceptableReason: IsAcceptableCatImageNotAcceptableReason;
+};
+
+export type IsAcceptableCatImage = (
+  request: IsAcceptableCatImageRequest,
+) => Promise<
+  RepositoryResult<IsAcceptableCatImageResponse, IsAcceptableCatImageError>
 >;

--- a/src/domain/repositories/imageRepository.ts
+++ b/src/domain/repositories/imageRepository.ts
@@ -1,5 +1,6 @@
 import FetchLgtmImagesAuthError from '../errors/FetchLgtmImagesAuthError';
 import FetchLgtmImagesError from '../errors/FetchLgtmImagesError';
+import IsAcceptableCatImageAuthError from '../errors/IsAcceptableCatImageAuthError';
 import IsAcceptableCatImageError from '../errors/IsAcceptableCatImageError';
 import UploadCatImageAuthError from '../errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../errors/UploadCatImageSizeTooLargeError';
@@ -42,7 +43,7 @@ export type UploadCatImage = (
 
 export type IsAcceptableCatImageRequest = UploadCatImageRequest;
 
-type IsAcceptableCatImageNotAcceptableReason =
+export type IsAcceptableCatImageNotAcceptableReason =
   | 'not an allowed image extension'
   | 'not moderation image'
   | 'person face in the image'
@@ -57,5 +58,8 @@ export type IsAcceptableCatImageResponse = {
 export type IsAcceptableCatImage = (
   request: IsAcceptableCatImageRequest,
 ) => Promise<
-  RepositoryResult<IsAcceptableCatImageResponse, IsAcceptableCatImageError>
+  RepositoryResult<
+    IsAcceptableCatImageResponse,
+    IsAcceptableCatImageError | IsAcceptableCatImageAuthError
+  >
 >;

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
@@ -6,13 +6,21 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
 import { isAcceptableCatImageUrl } from '../../../../../../constants/url';
+import IsAcceptableCatImageAuthError from '../../../../../../domain/errors/IsAcceptableCatImageAuthError';
+import IsAcceptableCatImageError from '../../../../../../domain/errors/IsAcceptableCatImageError';
 import {
   IsAcceptableCatImageNotAcceptableReason,
   IsAcceptableCatImageRequest,
 } from '../../../../../../domain/repositories/imageRepository';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import mockInternalServerError from '../../../../../../mocks/api/error/mockInternalServerError';
+import mockUnauthorizedError from '../../../../../../mocks/api/error/mockUnauthorizedError';
 import mockIsAcceptableCatImage from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImage';
+import mockIsAcceptableCatImageError from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImageError';
 import mockIsAcceptableCatImageNotAllowedImageExtension from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension';
+import mockIsAcceptableCatImageNotCatImage from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage';
+import mockIsAcceptableCatImageNotModerationImage from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage';
+import mockIsAcceptableCatImagePersonFaceInImage from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage';
 import { isAcceptableCatImage } from '../../imageRepository';
 
 const mockHandlers = [
@@ -76,5 +84,139 @@ describe('imageRepository.ts isAcceptableCatImage TestCases', () => {
 
     expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
     expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should result in isAcceptableCatImage being false because not moderation image', async () => {
+    mockServer.use(
+      rest.post(
+        isAcceptableCatImageUrl(),
+        mockIsAcceptableCatImageNotModerationImage,
+      ),
+    );
+
+    const expected = {
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not moderation image' as IsAcceptableCatImageNotAcceptableReason,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should result in isAcceptableCatImage being false because person face in the image', async () => {
+    mockServer.use(
+      rest.post(
+        isAcceptableCatImageUrl(),
+        mockIsAcceptableCatImagePersonFaceInImage,
+      ),
+    );
+
+    const expected = {
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'person face in the image' as IsAcceptableCatImageNotAcceptableReason,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should result in isAcceptableCatImage being false because not cat image', async () => {
+    mockServer.use(
+      rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImageNotCatImage),
+    );
+
+    const expected = {
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not cat image' as IsAcceptableCatImageNotAcceptableReason,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should result in isAcceptableCatImage being false because an error has occurred', async () => {
+    mockServer.use(
+      rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImageError),
+    );
+
+    const expected = {
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'an error has occurred' as IsAcceptableCatImageNotAcceptableReason,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should return an IsAcceptableCatImageAuthError because the accessToken is invalid', async () => {
+    mockServer.use(rest.post(isAcceptableCatImageUrl(), mockUnauthorizedError));
+
+    const expected = new IsAcceptableCatImageAuthError();
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const uploadedImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(uploadedImageResult)).toBeFalsy();
+    expect(uploadedImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should return an IsAcceptableCatImageError because the API will return internalServer error', async () => {
+    mockServer.use(
+      rest.post(isAcceptableCatImageUrl(), mockInternalServerError),
+    );
+
+    const expected = new IsAcceptableCatImageError();
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const uploadedImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(uploadedImageResult)).toBeFalsy();
+    expect(uploadedImageResult.value).toStrictEqual(expected);
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'whatwg-fetch';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { isAcceptableCatImageUrl } from '../../../../../../constants/url';
+import {
+  IsAcceptableCatImageNotAcceptableReason,
+  IsAcceptableCatImageRequest,
+} from '../../../../../../domain/repositories/imageRepository';
+import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import mockIsAcceptableCatImage from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImage';
+import mockIsAcceptableCatImageNotAllowedImageExtension from '../../../../../../mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension';
+import { isAcceptableCatImage } from '../../imageRepository';
+
+const mockHandlers = [
+  rest.post(isAcceptableCatImageUrl(), mockIsAcceptableCatImage),
+];
+
+const mockServer = setupServer(...mockHandlers);
+
+// eslint-disable-next-line max-lines-per-function
+describe('imageRepository.ts isAcceptableCatImage TestCases', () => {
+  beforeAll(() => {
+    mockServer.listen();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  it('should be true for isAcceptableCatImage', async () => {
+    const expected = {
+      isAcceptableCatImage: true,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: '',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+
+  it('should result in isAcceptableCatImage being false because not an allowed image extension', async () => {
+    mockServer.use(
+      rest.post(
+        isAcceptableCatImageUrl(),
+        mockIsAcceptableCatImageNotAllowedImageExtension,
+      ),
+    );
+
+    const expected = {
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not an allowed image extension' as IsAcceptableCatImageNotAcceptableReason,
+    };
+
+    const request: IsAcceptableCatImageRequest = {
+      accessToken: { jwtString: '' },
+      image: 'dummy image',
+      imageExtension: '.jpg',
+    };
+
+    const isAcceptableCatImageResult = await isAcceptableCatImage(request);
+
+    expect(isSuccessResult(isAcceptableCatImageResult)).toBeTruthy();
+    expect(isAcceptableCatImageResult.value).toStrictEqual(expected);
+  });
+});

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -2,16 +2,21 @@ import { httpStatusCode } from '../../../../constants/httpStatusCode';
 import {
   fetchLgtmImagesInRecentlyCreatedUrl,
   fetchLgtmImagesUrl,
+  isAcceptableCatImageUrl,
   uploadCatImageUrl,
 } from '../../../../constants/url';
 import FetchLgtmImagesAuthError from '../../../../domain/errors/FetchLgtmImagesAuthError';
 import FetchLgtmImagesError from '../../../../domain/errors/FetchLgtmImagesError';
+import IsAcceptableCatImageAuthError from '../../../../domain/errors/IsAcceptableCatImageAuthError';
+import IsAcceptableCatImageError from '../../../../domain/errors/IsAcceptableCatImageError';
 import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
 import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
 import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import {
   FetchLgtmImages,
+  IsAcceptableCatImage,
+  IsAcceptableCatImageResponse,
   UploadCatImage,
 } from '../../../../domain/repositories/imageRepository';
 import {
@@ -111,4 +116,40 @@ export const uploadCatImage: UploadCatImage = async (request) => {
   const uploadedImage = (await response.json()) as UploadedImage;
 
   return createSuccessResult<UploadedImage>(uploadedImage);
+};
+
+export const isAcceptableCatImage: IsAcceptableCatImage = async (request) => {
+  const options: RequestInit = {
+    method: 'POST',
+    mode: 'cors',
+    cache: 'no-cache',
+    headers: {
+      Authorization: `Bearer ${request.accessToken.jwtString}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      image: request.image,
+      imageExtension: request.imageExtension,
+    }),
+  };
+
+  const response = await fetch(isAcceptableCatImageUrl(), options);
+  if (response.status !== httpStatusCode.ok) {
+    if (response.status === httpStatusCode.unauthorized) {
+      return createFailureResult<IsAcceptableCatImageAuthError>(
+        new IsAcceptableCatImageAuthError(),
+      );
+    }
+
+    return createFailureResult<IsAcceptableCatImageError>(
+      new IsAcceptableCatImageError(),
+    );
+  }
+
+  const isAcceptableCatImageResponse =
+    (await response.json()) as IsAcceptableCatImageResponse;
+
+  return createSuccessResult<IsAcceptableCatImageResponse>(
+    isAcceptableCatImageResponse,
+  );
 };

--- a/src/infrastructures/utils/assertNever.ts
+++ b/src/infrastructures/utils/assertNever.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const assertNever = (value: never): never => {
+  throw new Error('Unexpected value. Should have been never.');
+};
+
+export default assertNever;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImage.ts
@@ -1,0 +1,16 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+
+const mockIsAcceptableCatImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: true,
+    }),
+  );
+
+export default mockIsAcceptableCatImage;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageError.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageError.ts
@@ -1,0 +1,19 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+import { IsAcceptableCatImageNotAcceptableReason } from '../../../../domain/repositories/imageRepository';
+
+const mockIsAcceptableCatImageError: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'an error has occurred' as IsAcceptableCatImageNotAcceptableReason,
+    }),
+  );
+
+export default mockIsAcceptableCatImageError;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotAllowedImageExtension.ts
@@ -1,0 +1,19 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+import { IsAcceptableCatImageNotAcceptableReason } from '../../../../domain/repositories/imageRepository';
+
+const mockIsAcceptableCatImageNotAllowedImageExtension: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not an allowed image extension' as IsAcceptableCatImageNotAcceptableReason,
+    }),
+  );
+
+export default mockIsAcceptableCatImageNotAllowedImageExtension;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotCatImage.ts
@@ -1,0 +1,19 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+import { IsAcceptableCatImageNotAcceptableReason } from '../../../../domain/repositories/imageRepository';
+
+const mockIsAcceptableCatImageNotCatImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not cat image' as IsAcceptableCatImageNotAcceptableReason,
+    }),
+  );
+
+export default mockIsAcceptableCatImageNotCatImage;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImageNotModerationImage.ts
@@ -1,0 +1,19 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+import { IsAcceptableCatImageNotAcceptableReason } from '../../../../domain/repositories/imageRepository';
+
+const mockIsAcceptableCatImageNotModerationImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'not moderation image' as IsAcceptableCatImageNotAcceptableReason,
+    }),
+  );
+
+export default mockIsAcceptableCatImageNotModerationImage;

--- a/src/mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage.ts
+++ b/src/mocks/api/external/recognition/mockIsAcceptableCatImagePersonFaceInImage.ts
@@ -1,0 +1,19 @@
+import { ResponseResolver, MockedRequest, restContext } from 'msw';
+
+import { httpStatusCode } from '../../../../constants/httpStatusCode';
+import { IsAcceptableCatImageNotAcceptableReason } from '../../../../domain/repositories/imageRepository';
+
+const mockIsAcceptableCatImagePersonFaceInImage: ResponseResolver<
+  MockedRequest,
+  typeof restContext
+> = (_req, res, ctx) =>
+  res(
+    ctx.status(httpStatusCode.ok),
+    ctx.json({
+      isAcceptableCatImage: false,
+      notAcceptableReason:
+        'person face in the image' as IsAcceptableCatImageNotAcceptableReason,
+    }),
+  );
+
+export default mockIsAcceptableCatImagePersonFaceInImage;

--- a/src/pages/api/oidc/token.ts
+++ b/src/pages/api/oidc/token.ts
@@ -58,7 +58,7 @@ const issueClientCredentialsAccessToken = async (
       'Content-Type': 'application/x-www-form-urlencoded',
       Authorization: `Basic ${authorization}`,
     },
-    body: 'grant_type=client_credentials&scope=api.lgtmeow/all',
+    body: 'grant_type=client_credentials&scope=api.lgtmeow/all image-recognition-api.lgtmeow/all',
   };
 
   const response = await fetch(cognitoTokenEndpointUrl(), options);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/100

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue100add-call-ccbf1a-nekochans.vercel.app/upload

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/100 のDoneの定義を満たしている事

# スクリーンショット

## 有効なねこ画像と判定されなかった場合のエラーメッセージの1例

![ErrorMessage](https://user-images.githubusercontent.com/11032365/164980908-960dcd98-1a2c-4c24-a28d-5c25cfc3c09a.png)

## アップロード後のメッセージ

![afterUpload](https://user-images.githubusercontent.com/11032365/164980922-f2e804fe-80d7-4429-bda3-434bf8e592ab.png)

# 変更点概要

https://github.com/nekochans/lgtm-cat-image-recognition/pull/40 で作成したAPIを利用してアップロード前に事前に有効なねこ画像かどうかの判定を行うように変更。

Storybookには各パターンを全て確認出来るようにStoryを追加。

事前にねこ画像かどうかを確認するので、アップロード完了後の画像が利用出来ないというケースは基本的にはなくなったのでアップロード後のメッセージを変更。

変更後のメッセージを確認する為にはStorybook上でアップロードを完了させると確認出来る。

https://622b6c5dc31e9e003a111eb5-xdtpmpvgkr.chromatic.com/?path=/story/src-components-catimageuploadform-tsx--upload-will-be-successful

# レビュアーに重点的にチェックして欲しい点

アップロード完了後のメッセージがこれで良いか確認してもらえると:pray:

# 補足情報

本番にデプロイする前に https://github.com/nekochans/lgtm-cat-image-recognition/pull/44 をデプロイする必要がある。