### PR TITLE
API通信を行うコード内で例外が発生した際は例外をそのままthrowするように変更

### DIFF
--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -18,6 +18,7 @@ import { sendUploadCatImage } from '../infrastructures/utils/gtm';
 import CatImageUploadConfirmModal from './CatImageUploadConfirmModal';
 import CatImageUploadDescription from './CatImageUploadDescription';
 import CatImageUploadError from './CatImageUploadError';
+import UploadCatImageUnexpectedError from '../domain/errors/UploadCatImageUnexpectedError';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];
@@ -211,18 +212,16 @@ const CatImageUploadForm: VFC<Props> = ({ uploadCatImage }) => {
 
       sendUploadCatImage('upload_cat_image_button');
     } catch (error) {
-      const newError =
-        error instanceof Error
-          ? error
-          : new Error('onClickUpload Unexpected error');
-      setErrorMessage(createDisplayErrorMessage(newError));
-      setImagePreviewUrl('');
-      setUploadImageExtension('');
-      setCreatedLgtmImageUrl('');
-      setIsLoading(false);
-      closeModal();
+      if (error instanceof UploadCatImageUnexpectedError) {
+        setErrorMessage(createDisplayErrorMessage(error));
+        setImagePreviewUrl('');
+        setUploadImageExtension('');
+        setCreatedLgtmImageUrl('');
+        setIsLoading(false);
+        closeModal();
 
-      throw newError;
+        throw error;
+      }
     }
   };
 

--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -3,6 +3,7 @@
 import { useState, type VFC, ChangeEvent, FormEvent } from 'react';
 
 import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSizeTooLargeError';
+import UploadCatImageUnexpectedError from '../domain/errors/UploadCatImageUnexpectedError';
 import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';
 import {
   AcceptedTypesImageExtension,
@@ -18,7 +19,6 @@ import { sendUploadCatImage } from '../infrastructures/utils/gtm';
 import CatImageUploadConfirmModal from './CatImageUploadConfirmModal';
 import CatImageUploadDescription from './CatImageUploadDescription';
 import CatImageUploadError from './CatImageUploadError';
-import UploadCatImageUnexpectedError from '../domain/errors/UploadCatImageUnexpectedError';
 
 // TODO acceptedTypesは定数化して分離する
 const acceptedTypes: string[] = ['image/png', 'image/jpg', 'image/jpeg'];

--- a/src/infrastructures/repositories/api/fetch/__tests__/authTokenRepository/issueAccessToken.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/authTokenRepository/issueAccessToken.spec.ts
@@ -6,7 +6,9 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
 import { apiList } from '../../../../../../constants/url';
+import IssueAccessTokenError from '../../../../../../domain/errors/IssueAccessTokenError';
 import { isSuccessResult } from '../../../../../../domain/repositories/repositoryResult';
+import mockInternalServerError from '../../../../../../mocks/api/error/mockInternalServerError';
 import mockTokenEndpoint from '../../../../../../mocks/api/external/cognito/mockTokenEndpoint';
 import { issueAccessToken } from '../../authTokenRepository';
 
@@ -41,5 +43,16 @@ describe('authTokenRepository.ts issueAccessToken TestCases', () => {
     expect(accessTokenResult.value).toStrictEqual(expectedValue);
   });
 
-  // TODO 異常系のテストケースを実装する
+  it('should throw an IssueAccessTokenError because the API will return internalServer error', async () => {
+    mockServer.use(
+      rest.post(
+        apiList.issueClientCredentialsAccessToken,
+        mockInternalServerError,
+      ),
+    );
+
+    const expectedValue = new IssueAccessTokenError('Internal Server Error');
+
+    await expect(issueAccessToken()).rejects.toStrictEqual(expectedValue);
+  });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRandom.spec.ts
@@ -57,14 +57,13 @@ describe('imageRepository.ts fetchLgtmImagesInRandom TestCases', () => {
     );
   });
 
-  it('should return an FetchLgtmImagesError because Failed to fetch LGTM Images', async () => {
+  it('should throw a FetchLgtmImagesError because Failed to fetch LGTM Images', async () => {
     mockServer.use(rest.get(fetchLgtmImagesUrl(), mockInternalServerError));
 
-    const lgtmImagesResponse = await fetchLgtmImagesInRandom({
-      accessToken: { jwtString: '' },
-    });
+    const request = { accessToken: { jwtString: '' } };
 
-    expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
-    expect(lgtmImagesResponse.value).toStrictEqual(new FetchLgtmImagesError());
+    await expect(fetchLgtmImagesInRandom(request)).rejects.toStrictEqual(
+      new FetchLgtmImagesError('Internal Server Error'),
+    );
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRecentlyCreated.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/fetchLgtmImagesInRecentlyCreated.ts
@@ -61,16 +61,15 @@ describe('imageRepository.ts fetchLgtmImagesInRecentlyCreated TestCases', () => 
     );
   });
 
-  it('should return an FetchLgtmImagesError because Failed to fetch LGTM Images', async () => {
+  it('should throw a FetchLgtmImagesError because Failed to fetch LGTM Images', async () => {
     mockServer.use(
       rest.get(fetchLgtmImagesInRecentlyCreatedUrl(), mockInternalServerError),
     );
 
-    const lgtmImagesResponse = await fetchLgtmImagesInRecentlyCreated({
-      accessToken: { jwtString: '' },
-    });
+    const request = { accessToken: { jwtString: '' } };
 
-    expect(isSuccessResult(lgtmImagesResponse)).toBeFalsy();
-    expect(lgtmImagesResponse.value).toStrictEqual(new FetchLgtmImagesError());
+    await expect(
+      fetchLgtmImagesInRecentlyCreated(request),
+    ).rejects.toStrictEqual(new FetchLgtmImagesError('Internal Server Error'));
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/isAcceptableCatImage.spec.ts
@@ -206,7 +206,7 @@ describe('imageRepository.ts isAcceptableCatImage TestCases', () => {
       rest.post(isAcceptableCatImageUrl(), mockInternalServerError),
     );
 
-    const expected = new IsAcceptableCatImageError();
+    const expected = new IsAcceptableCatImageError('Internal Server Error');
 
     const request: IsAcceptableCatImageRequest = {
       accessToken: { jwtString: '' },
@@ -214,9 +214,6 @@ describe('imageRepository.ts isAcceptableCatImage TestCases', () => {
       imageExtension: '.jpg',
     };
 
-    const uploadedImageResult = await isAcceptableCatImage(request);
-
-    expect(isSuccessResult(uploadedImageResult)).toBeFalsy();
-    expect(uploadedImageResult.value).toStrictEqual(expected);
+    await expect(isAcceptableCatImage(request)).rejects.toStrictEqual(expected);
   });
 });

--- a/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/uploadCatImage.spec.ts
+++ b/src/infrastructures/repositories/api/fetch/__tests__/imageRepository/uploadCatImage.spec.ts
@@ -111,10 +111,10 @@ describe('imageRepository.ts uploadCatImage TestCases', () => {
     expect(uploadedImageResult.value).toStrictEqual(expected);
   });
 
-  it('should return an UploadCatImageUnexpectedError because the API will return unexpected error', async () => {
+  it('should throw a UploadCatImageUnexpectedError because the API will return unexpected error', async () => {
     mockServer.use(rest.post(uploadCatImageUrl(), mockInternalServerError));
 
-    const expected = new UploadCatImageUnexpectedError();
+    const expected = new UploadCatImageUnexpectedError('Internal Server Error');
 
     const request: UploadCatImageRequest = {
       accessToken: { jwtString: '' },
@@ -122,9 +122,6 @@ describe('imageRepository.ts uploadCatImage TestCases', () => {
       imageExtension: '.jpg',
     };
 
-    const uploadedImageResult = await uploadCatImage(request);
-
-    expect(isSuccessResult(uploadedImageResult)).toBeFalsy();
-    expect(uploadedImageResult.value).toStrictEqual(expected);
+    await expect(uploadCatImage(request)).rejects.toStrictEqual(expected);
   });
 });

--- a/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
@@ -2,40 +2,25 @@ import { httpStatusCode } from '../../../../constants/httpStatusCode';
 import { apiList, appBaseUrl } from '../../../../constants/url';
 import IssueAccessTokenError from '../../../../domain/errors/IssueAccessTokenError';
 import { IssueAccessToken } from '../../../../domain/repositories/authTokenRepository';
-import {
-  createFailureResult,
-  createSuccessResult,
-} from '../../../../domain/repositories/repositoryResult';
+import { createSuccessResult } from '../../../../domain/repositories/repositoryResult';
 import { AccessToken } from '../../../../domain/types/authToken';
 
 // eslint-disable-next-line import/prefer-default-export
 export const issueAccessToken: IssueAccessToken = async () => {
-  try {
-    const options = {
-      method: 'POST',
-    };
+  const options = {
+    method: 'POST',
+  };
 
-    const response = await fetch(
-      `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
-      options,
-    );
+  const response = await fetch(
+    `${appBaseUrl()}${apiList.issueClientCredentialsAccessToken}`,
+    options,
+  );
 
-    const responseBody = (await response.json()) as AccessToken;
+  const responseBody = (await response.json()) as AccessToken;
 
-    if (response.status !== httpStatusCode.ok || !responseBody.jwtString) {
-      return createFailureResult<IssueAccessTokenError>(
-        new IssueAccessTokenError(),
-      );
-    }
-
-    return createSuccessResult<AccessToken>(responseBody);
-  } catch (error) {
-    // TODO このブロックに入った時は原因不明なエラーなのでSlack等に通知を送信したい
-    const newError =
-      error instanceof Error
-        ? new IssueAccessTokenError(error.message)
-        : new IssueAccessTokenError('issueAccessToken Unexpected error');
-
-    return createFailureResult<IssueAccessTokenError>(newError);
+  if (response.status !== httpStatusCode.ok || !responseBody.jwtString) {
+    throw new IssueAccessTokenError(response.statusText);
   }
+
+  return createSuccessResult<AccessToken>(responseBody);
 };

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -41,7 +41,7 @@ export const fetchLgtmImagesInRandom: FetchLgtmImages = async (request) => {
       return createFailureResult(new FetchLgtmImagesAuthError());
     }
 
-    return createFailureResult(new FetchLgtmImagesError());
+    throw new FetchLgtmImagesError(response.statusText);
   }
 
   const lgtmImages = (await response.json()) as LgtmImages;
@@ -67,7 +67,7 @@ export const fetchLgtmImagesInRecentlyCreated: FetchLgtmImages = async (
       return createFailureResult(new FetchLgtmImagesAuthError());
     }
 
-    return createFailureResult(new FetchLgtmImagesError());
+    throw new FetchLgtmImagesError(response.statusText);
   }
 
   const lgtmImages = (await response.json()) as LgtmImages;
@@ -107,9 +107,7 @@ export const uploadCatImage: UploadCatImage = async (request) => {
           new UploadCatImageValidationError(),
         );
       default:
-        return createFailureResult<UploadCatImageUnexpectedError>(
-          new UploadCatImageUnexpectedError(),
-        );
+        throw new UploadCatImageUnexpectedError(response.statusText);
     }
   }
 
@@ -141,9 +139,7 @@ export const isAcceptableCatImage: IsAcceptableCatImage = async (request) => {
       );
     }
 
-    return createFailureResult<IsAcceptableCatImageError>(
-      new IsAcceptableCatImageError(),
-    );
+    throw new IsAcceptableCatImageError(response.statusText);
   }
 
   const isAcceptableCatImageResponse =

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -9,10 +9,12 @@ import FetchLgtmImagesAuthError from '../../../../domain/errors/FetchLgtmImagesA
 import FetchLgtmImagesError from '../../../../domain/errors/FetchLgtmImagesError';
 import IsAcceptableCatImageAuthError from '../../../../domain/errors/IsAcceptableCatImageAuthError';
 import IsAcceptableCatImageError from '../../../../domain/errors/IsAcceptableCatImageError';
-import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
-import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
+/*
+ * Import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
+ * import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
+ */
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
-import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
+// Import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import {
   FetchLgtmImages,
   IsAcceptableCatImage,
@@ -92,23 +94,8 @@ export const uploadCatImage: UploadCatImage = async (request) => {
 
   const response = await fetch(uploadCatImageUrl(), options);
 
-  if (response.status !== httpStatusCode.accepted) {
-    switch (response.status) {
-      case httpStatusCode.unauthorized:
-        return createFailureResult<UploadCatImageAuthError>(
-          new UploadCatImageAuthError(),
-        );
-      case httpStatusCode.payloadTooLarge:
-        return createFailureResult<UploadCatImageSizeTooLargeError>(
-          new UploadCatImageSizeTooLargeError(),
-        );
-      case httpStatusCode.unprocessableEntity:
-        return createFailureResult<UploadCatImageValidationError>(
-          new UploadCatImageValidationError(),
-        );
-      default:
-        throw new UploadCatImageUnexpectedError(response.statusText);
-    }
+  if (response.status === httpStatusCode.accepted) {
+    throw new UploadCatImageUnexpectedError(response.statusText);
   }
 
   const uploadedImage = (await response.json()) as UploadedImage;

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -9,12 +9,10 @@ import FetchLgtmImagesAuthError from '../../../../domain/errors/FetchLgtmImagesA
 import FetchLgtmImagesError from '../../../../domain/errors/FetchLgtmImagesError';
 import IsAcceptableCatImageAuthError from '../../../../domain/errors/IsAcceptableCatImageAuthError';
 import IsAcceptableCatImageError from '../../../../domain/errors/IsAcceptableCatImageError';
-/*
- * Import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
- * import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
- */
+import UploadCatImageAuthError from '../../../../domain/errors/UploadCatImageAuthError';
+import UploadCatImageSizeTooLargeError from '../../../../domain/errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../../../../domain/errors/UploadCatImageUnexpectedError';
-// Import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
+import UploadCatImageValidationError from '../../../../domain/errors/UploadCatImageValidationError';
 import {
   FetchLgtmImages,
   IsAcceptableCatImage,
@@ -94,8 +92,23 @@ export const uploadCatImage: UploadCatImage = async (request) => {
 
   const response = await fetch(uploadCatImageUrl(), options);
 
-  if (response.status === httpStatusCode.accepted) {
-    throw new UploadCatImageUnexpectedError(response.statusText);
+  if (response.status !== httpStatusCode.accepted) {
+    switch (response.status) {
+      case httpStatusCode.unauthorized:
+        return createFailureResult<UploadCatImageAuthError>(
+          new UploadCatImageAuthError(),
+        );
+      case httpStatusCode.payloadTooLarge:
+        return createFailureResult<UploadCatImageSizeTooLargeError>(
+          new UploadCatImageSizeTooLargeError(),
+        );
+      case httpStatusCode.unprocessableEntity:
+        return createFailureResult<UploadCatImageValidationError>(
+          new UploadCatImageValidationError(),
+        );
+      default:
+        throw new UploadCatImageUnexpectedError(response.statusText);
+    }
   }
 
   const uploadedImage = (await response.json()) as UploadedImage;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/165

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue165refactor-8e6579-nekochans.vercel.app/

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/165 のDoneの定義を満たしている事

# スクリーンショット

![sentry](https://user-images.githubusercontent.com/11032365/168459574-edbf67e6-ee15-47cd-a089-c6ca43842aa1.png)

# 変更点概要

明らかに例外と言えるケースに関しては例外をThrowするように変更。

https://github.com/nekochans/lgtm-cat-frontend/issues/165 にも書いてあるが例外と思われるケースをResult型でラップするとSentryに通知が送られずにデバッグが困難になってしまう為である。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

なし
