### PR TITLE
SentryにX-Request-Idが記録されるように変更

### DIFF
--- a/src/components/CatImageUploadForm.tsx
+++ b/src/components/CatImageUploadForm.tsx
@@ -2,6 +2,7 @@
 // TODO https://github.com/nekochans/lgtm-cat-frontend/issues/107 を実施する際にファイル先頭のESLintの制御コメントを削除する
 import { useState, type VFC, ChangeEvent, FormEvent } from 'react';
 
+import IsAcceptableCatImageError from '../domain/errors/IsAcceptableCatImageError';
 import UploadCatImageSizeTooLargeError from '../domain/errors/UploadCatImageSizeTooLargeError';
 import UploadCatImageUnexpectedError from '../domain/errors/UploadCatImageUnexpectedError';
 import UploadCatImageValidationError from '../domain/errors/UploadCatImageValidationError';
@@ -212,7 +213,10 @@ const CatImageUploadForm: VFC<Props> = ({ uploadCatImage }) => {
 
       sendUploadCatImage('upload_cat_image_button');
     } catch (error) {
-      if (error instanceof UploadCatImageUnexpectedError) {
+      if (
+        error instanceof UploadCatImageUnexpectedError ||
+        error instanceof IsAcceptableCatImageError
+      ) {
         setErrorMessage(createDisplayErrorMessage(error));
         setImagePreviewUrl('');
         setUploadImageExtension('');

--- a/src/infrastructures/repositories/api/fetch/imageRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/imageRepository.ts
@@ -24,6 +24,7 @@ import {
   createSuccessResult,
 } from '../../../../domain/repositories/repositoryResult';
 import { LgtmImages, UploadedImage } from '../../../../domain/types/lgtmImage';
+import { mightSetRequestIdToSentry } from '../../../utils/sentry';
 
 export const fetchLgtmImagesInRandom: FetchLgtmImages = async (request) => {
   const options: RequestInit = {
@@ -40,6 +41,8 @@ export const fetchLgtmImagesInRandom: FetchLgtmImages = async (request) => {
     if (response.status === httpStatusCode.unauthorized) {
       return createFailureResult(new FetchLgtmImagesAuthError());
     }
+
+    await mightSetRequestIdToSentry(response);
 
     throw new FetchLgtmImagesError(response.statusText);
   }
@@ -66,6 +69,8 @@ export const fetchLgtmImagesInRecentlyCreated: FetchLgtmImages = async (
     if (response.status === httpStatusCode.unauthorized) {
       return createFailureResult(new FetchLgtmImagesAuthError());
     }
+
+    await mightSetRequestIdToSentry(response);
 
     throw new FetchLgtmImagesError(response.statusText);
   }
@@ -107,6 +112,7 @@ export const uploadCatImage: UploadCatImage = async (request) => {
           new UploadCatImageValidationError(),
         );
       default:
+        await mightSetRequestIdToSentry(response);
         throw new UploadCatImageUnexpectedError(response.statusText);
     }
   }
@@ -138,6 +144,8 @@ export const isAcceptableCatImage: IsAcceptableCatImage = async (request) => {
         new IsAcceptableCatImageAuthError(),
       );
     }
+
+    await mightSetRequestIdToSentry(response);
 
     throw new IsAcceptableCatImageError(response.statusText);
   }

--- a/src/infrastructures/utils/sentry.ts
+++ b/src/infrastructures/utils/sentry.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/nextjs';
+
+export const mightSetRequestIdToSentry = async (response: Response) => {
+  const xRequestId = await response.headers.get('x-request-id');
+  if (xRequestId) {
+    Sentry.configureScope((scope) => {
+      scope.setTag('x_request_id', xRequestId);
+    });
+  }
+
+  const lambdaRequestId = await response.headers.get('x-lambda-request-id');
+  if (lambdaRequestId) {
+    Sentry.configureScope((scope) => {
+      scope.setTag('x_lambda_request_id', lambdaRequestId);
+    });
+  }
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/169

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue169x-request-id-nekochans.vercel.app

※動作確認時にはVercel上のPreview環境の環境変数 `NEXT_PUBLIC_APP_URL` を上記に修正する必要がある。

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/169 のDoneの定義を満たしている事

# スクリーンショット

## Sentry上でリクエストIDが確認出来る

![sentry](https://user-images.githubusercontent.com/11032365/168608961-7e21cc0f-55e1-4db6-a7c3-003e1cf66060.png)

## AWS上でのログ確認（Sentry上で確認出来るリクエストIDがAWS側でも確認出来る）

![aws](https://user-images.githubusercontent.com/11032365/168609103-aea3caae-389e-4b80-9178-ad38f5da5216.png)

# 変更点概要

ねこ画像判定APIから `X-Request-Id` と `X-Lambda-Request-Id` という2つのHTTPカスタムヘッダーを返している。（目的はAPIのログをトレースする為）

この2つのHTTPヘッダーをSentry上で確認出来るように設定を追加。

設定は以下の公式ブログを参考にした。

https://blog.sentry.io/2019/01/31/using-nginx-sentry-trace-errors-logs

https://github.com/nekochans/lgtm-cat-api はまだ上記のHeaderが設定されていないが将来的に追加される事を見越して関数の埋め込みだけ行っている。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

本PRは https://github.com/nekochans/lgtm-cat-frontend/pull/175 に依存している。

本PRのデプロイ前に https://github.com/nekochans/lgtm-cat-image-recognition/pull/48 がデプロイされている必要がある。