### PR TITLE
環境変数によってメンテナンス中のエラーページを返す処理を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ export SENTRY_AUTH_TOKEN=Sentryのトークン（Vercel上の値を参照）
 
 `http://localhost:2222` でアクセス可能です。
 
+## メンテナンスモードについて
+
+`IS_IN_MAINTENANCE` が `1` の場合はメンテナンスページを強制的に表示します。
+
 ## 開発でよく使うコマンド
 
 ### `npm run lint`

--- a/src/constants/metaTag.ts
+++ b/src/constants/metaTag.ts
@@ -50,4 +50,10 @@ export const metaTagList = (): MetaTagList => ({
     ogpTargetUrl: urlList.privacy,
     appName,
   },
+  maintenance: {
+    title: `${defaultTitle} メンテナンス`,
+    ogpImgUrl: urlList.ogpImg,
+    ogpTargetUrl: urlList.privacy,
+    appName,
+  },
 });

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -21,9 +21,15 @@ export const pathList = {
   terms: '/terms',
   privacy: '/privacy',
   error: '/error',
+  maintenance: '/maintenance',
 } as const;
 
-export type AppPathName = 'top' | 'upload' | 'terms' | 'privacy';
+export type AppPathName =
+  | 'top'
+  | 'upload'
+  | 'terms'
+  | 'privacy'
+  | 'maintenance';
 
 // この関数はサーバーサイドでしか動作しない
 export const cognitoTokenEndpointUrl = (): string =>

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const middleware = (req: NextRequest) => {
+  const url = req.nextUrl.clone();
+
+  if (process.env.IS_IN_MAINTENANCE === '1') {
+    url.pathname = '/maintenance';
+
+    return NextResponse.rewrite(url);
+  }
+
+  return NextResponse.next();
+};
+
+export default middleware;

--- a/src/pages/maintenance.tsx
+++ b/src/pages/maintenance.tsx
@@ -1,0 +1,24 @@
+import { NextPage } from 'next';
+import Link from 'next/link';
+
+import ErrorContent from '../components/ErrorContent';
+import ErrorLayout from '../components/ErrorLayout';
+import { metaTagList } from '../constants/metaTag';
+import { pathList } from '../constants/url';
+
+const MaintenancePage: NextPage = () => (
+  <ErrorLayout title={metaTagList().maintenance.title}>
+    <ErrorContent
+      title="システムメンテナンス"
+      message="メンテナンス中です。申し訳ありませんがしばらく時間がたってからお試しください。"
+      topLink={
+        <Link href={pathList.top}>
+          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+          <a>TOPページへ</a>
+        </Link>
+      }
+    />
+  </ErrorLayout>
+);
+
+export default MaintenancePage;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/140

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue140add-main-0b3161-nekochans.vercel.app

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/140 に記載してある通りメンテナンスページが実装されている事

# スクリーンショット

## 今回作成したメンテナンスページ

![maintenancePage](https://user-images.githubusercontent.com/11032365/169505800-e9686f04-1bfa-4c46-8afb-d8ff1e059231.png)

# 変更点概要

環境変数 `IS_IN_MAINTENANCE` が `1` の場合、[Middleware](https://vercel.com/docs/concepts/functions/edge-functions/middleware) を利用してメンテナンスページを強制的に表示させる処理を追加。

実装は公式の https://github.com/vercel/examples/tree/main/edge-functions/maintenance-page を参考にした。 

普段から `/maintenance` のページは閲覧出来るようになっているがこのページにはNoindexが効いているのでGoogle検索の対象になる事はない。

本当はHTTPステータスコードも503にしたかったが標準機能では出来なさそうだったのでステータスコードは200を返している。

# レビュアーに重点的にチェックして欲しい点

実装方針問題ないか確認してもらえると:pray:

# 補足情報

特になし