### PR TITLE
npm ci 実行時に --legacy-peer-deps を渡すように変更

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: |
-          npm ci
+          npm ci --legacy-peer-deps
           npm run lint
           npm run test:ci
         env:

--- a/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
+++ b/src/infrastructures/repositories/api/fetch/authTokenRepository.ts
@@ -1,9 +1,18 @@
 import { httpStatusCode } from '../../../../constants/httpStatusCode';
-import { apiList, appBaseUrl } from '../../../../constants/url';
+import {
+  cognitoClientId,
+  cognitoClientSecret,
+} from '../../../../constants/secret';
+import {
+  apiList,
+  appBaseUrl,
+  cognitoTokenEndpointUrl,
+} from '../../../../constants/url';
 import IssueAccessTokenError from '../../../../domain/errors/IssueAccessTokenError';
 import { IssueAccessToken } from '../../../../domain/repositories/authTokenRepository';
 import { createSuccessResult } from '../../../../domain/repositories/repositoryResult';
 import { AccessToken } from '../../../../domain/types/authToken';
+import { CognitoTokenResponseBody } from '../../../../pages/api/oidc/token';
 
 // eslint-disable-next-line import/prefer-default-export
 export const issueAccessToken: IssueAccessToken = async () => {
@@ -23,4 +32,35 @@ export const issueAccessToken: IssueAccessToken = async () => {
   }
 
   return createSuccessResult<AccessToken>(responseBody);
+};
+
+/*
+ * この関数はサーバーサイドでしか動作しない
+ * TODO Cloudflare WorkersでAPI Proxyを構築するなどしてアクセストークン周りの処理は将来的に API Proxy に移行したい
+ * https://github.com/nekochans/lgtm-cat/issues/17
+ */
+export const issueAccessTokenOnServer: IssueAccessToken = async () => {
+  const authorization = Buffer.from(
+    `${cognitoClientId()}:${cognitoClientSecret()}`,
+  ).toString('base64');
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Basic ${authorization}`,
+    },
+    body: 'grant_type=client_credentials&scope=api.lgtmeow/all image-recognition-api.lgtmeow/all',
+  };
+
+  const response = await fetch(cognitoTokenEndpointUrl(), options);
+  if (!response.ok) {
+    throw new IssueAccessTokenError(response.statusText);
+  }
+
+  const responseBody = (await response.json()) as CognitoTokenResponseBody;
+
+  return createSuccessResult<AccessToken>({
+    jwtString: responseBody.access_token,
+  });
 };

--- a/src/pages/api/oidc/token.ts
+++ b/src/pages/api/oidc/token.ts
@@ -12,7 +12,7 @@ import {
 import { cognitoTokenEndpointUrl } from '../../../constants/url';
 import { AccessToken } from '../../../domain/types/authToken';
 
-type CognitoTokenResponseBody = {
+export type CognitoTokenResponseBody = {
   // eslint-disable-next-line camelcase
   access_token: string;
   // eslint-disable-next-line camelcase

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { metaTagList } from '../constants/metaTag';
 import ImageListContainer from '../containers/ImageListContainer';
 import { isSuccessResult } from '../domain/repositories/repositoryResult';
 import { LgtmImages } from '../domain/types/lgtmImage';
-import { issueAccessToken } from '../infrastructures/repositories/api/fetch/authTokenRepository';
+import { issueAccessTokenOnServer } from '../infrastructures/repositories/api/fetch/authTokenRepository';
 import { fetchLgtmImagesInRandom } from '../infrastructures/repositories/api/fetch/imageRepository';
 import imageData from '../infrastructures/utils/imageData';
 import extractRandomImages from '../infrastructures/utils/randomImages';
@@ -33,7 +33,7 @@ const IndexPage: NextPage<Props> = ({ lgtmImages }) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const issueAccessTokenResult = await issueAccessToken();
+  const issueAccessTokenResult = await issueAccessTokenOnServer();
   if (isSuccessResult(issueAccessTokenResult)) {
     const lgtmImagesResult = await fetchLgtmImagesInRandom({
       accessToken: { jwtString: issueAccessTokenResult.value.jwtString },


### PR DESCRIPTION
# issueURL

- https://github.com/nekochans/lgtm-cat-frontend/issues/181

# 関連 URL

なし

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/181 のDoneの定義を満たしている事

# スクリーンショット

なし

# 変更点概要

あるタイミングでGitHubActions上で `npm ci` を実行した際にも `--legacy-peer-deps` の指定が必要になったので追加。

もちろん `--legacy-peer-deps` なしで `package-lock.json` を構成している場合はこのオプションは不要。

しかし現状は最新のStorybookなどを入れる為にはこのオプションが必要なので、今は `--legacy-peer-deps` が必要と判断している。

それから本件解決時にVercelでのデプロイが失敗している事に気がついた。

https://vercel.com/nekochans/lgtm-cat-frontend/7KfR9xxD2CE6GXqUqCJ4RrkapgRR

原因はISRやSSGで利用する `getStaticProps` 内ではNext.jsのAPIルートのAPIはコール出来ない仕様になっている為。
（そもそも今まで何故に平気だったのか謎・・・）

https://github.com/nekochans/lgtm-cat-frontend/pull/182/commits/a2c48da10ff7c1e8c7dde391131b72d03907c9d7 のコミットで修正した。

このあたりはもう少し整理出来そうだが https://github.com/nekochans/lgtm-cat/issues/17 でCloudflare WorkersでAPI Proxyを構築する予定なのでそうなるとアクセストークン周りの処理は本アプリケーションから消える事になるので今はこのままで良いと判断している。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

特になし