### PR TITLE
CIに認証用のトークンを渡すように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@nekochans'
       - run: |
           npm ci --legacy-peer-deps
           npm run lint
@@ -31,6 +33,7 @@ jobs:
           COGNITO_TOKEN_ENDPOINT: ${{ secrets.COGNITO_TOKEN_ENDPOINT }}
           NEXT_PUBLIC_LGTMEOW_API_URL: ${{ secrets.NEXT_PUBLIC_LGTMEOW_API_URL }}
           NEXT_PUBLIC_IMAGE_RECOGNITION_API_URL: ${{ secrets.NEXT_PUBLIC_IMAGE_RECOGNITION_API_URL }}
+          NODE_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_FOR_GITHUB_PACKAGES }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/184

# 関連 URL

なし

# Done の定義

- CI実行時の環境変数に `NODE_AUTH_TOKEN` が追加されている事

# Storybook の URL もしくはスクリーンショット

UI変更がないのでなし

# 変更点概要

`@nekochans/lgtm-cat-ui` を利用するのでGItHubPackageの認証情報を追加。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
