### PR TITLE
Storybookデプロイ時の環境変数にGitHubPackageの認証トークンを追加

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,14 +6,22 @@ jobs:
   chromatic-deployment:
     name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://npm.pkg.github.com'
+          cache: 'npm'
+          scope: '@nekochans'
+      - run: npm ci --legacy-peer-deps
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN_FOR_GITHUB_PACKAGES }}
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/184

# 関連 URL

なし

# Done の定義

- Storybookデプロイ時の環境変数に `NODE_AUTH_TOKEN` が追加されている事

# Storybook の URL もしくはスクリーンショット

UI変更がないのでなし

# 変更点概要

`@nekochans/lgtm-cat-ui` を利用するのでGItHubPackageの認証情報を追加。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下の理由によりレビューなしでマージする。

- デザイナーさんに組み込み済のStorybookを早めに見せてデザインをブラッシュアップを図りたい
- かなりの数のPRを出す事になるので全てをレビューしてもらうとレビュアーの負担が大きい

PRの説明欄や「レビュアーに重点的にチェックして欲しい点」に関しては、いつも通り書いておくので、マージ後でも気になった点があればコメントしいてもらい、その内容は別issueなどで対応する。
