### PR TITLE
重複コンテンツ回避のため、altrenateタグとcanonicalタグを追加

### DIFF
--- a/src/features/url.ts
+++ b/src/features/url.ts
@@ -1,3 +1,5 @@
+import { Language } from './language';
+
 export type Url = `http://localhost${string}` | `https://${string}`;
 
 export const isUrl = (value: unknown): value is Url => {
@@ -51,6 +53,31 @@ export const appUrlList = {
   privacy: `${appBaseUrl()}${appPathList.privacy}` as const,
   maintenance: `${appBaseUrl()}${appPathList.maintenance}` as const,
 } as const;
+
+type I18nUrlList = {
+  [key in AppPathName]?: {
+    [childrenKey in Language]: Url;
+  };
+};
+
+export const i18nUrlList: I18nUrlList = {
+  top: {
+    ja: `${appUrlList.top}/`,
+    en: `${appBaseUrl()}/en/`,
+  },
+  upload: {
+    ja: `${appUrlList.upload}/`,
+    en: `${appBaseUrl()}/en${appPathList.upload}/`,
+  },
+  terms: {
+    ja: `${appUrlList.terms}/`,
+    en: `${appBaseUrl()}/en${appPathList.terms}/`,
+  },
+  privacy: {
+    ja: `${appUrlList.privacy}/`,
+    en: `${appBaseUrl()}/en${appPathList.privacy}/`,
+  },
+};
 
 export type AppUrl = typeof appUrlList[keyof typeof appUrlList];
 

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -5,20 +5,20 @@ import type { FC, ReactNode } from 'react';
 
 type Props = {
   metaTag: MetaTag;
-  canonicalLink: Url;
-  alternateUrls: {
-    link: Url;
-    hreflang: Language;
-  }[];
   children: ReactNode;
+  canonicalLink?: Url;
+  alternateUrls?: {
+    hreflang: Language;
+    link?: Url;
+  }[];
 };
 
 // eslint-disable-next-line max-lines-per-function
 export const DefaultLayout: FC<Props> = ({
   metaTag,
+  children,
   canonicalLink,
   alternateUrls,
-  children,
 }) => (
   <>
     <Head>
@@ -52,8 +52,8 @@ export const DefaultLayout: FC<Props> = ({
       <meta name="msapplication-TileColor" content="#da532c" />
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
       <meta name="theme-color" content="#ffffff" />
-      <link rel="canonical" href={canonicalLink} />
-      {alternateUrls.map((alternateUrl, index) => (
+      {canonicalLink ? <link rel="canonical" href={canonicalLink} /> : ''}
+      {alternateUrls?.map((alternateUrl, index) => (
         <link
           rel="alternate"
           hrefLang={alternateUrl.hreflang}

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -1,14 +1,25 @@
 import Head from 'next/head';
 
-import type { MetaTag } from '../../features';
+import type { Language, MetaTag, Url } from '../../features';
 import type { FC, ReactNode } from 'react';
 
 type Props = {
   metaTag: MetaTag;
+  canonicalLink: Url;
+  alternateUrls: {
+    link: Url;
+    hreflang: Language;
+  }[];
   children: ReactNode;
 };
 
-export const DefaultLayout: FC<Props> = ({ metaTag, children }) => (
+// eslint-disable-next-line max-lines-per-function
+export const DefaultLayout: FC<Props> = ({
+  metaTag,
+  canonicalLink,
+  alternateUrls,
+  children,
+}) => (
   <>
     <Head>
       <title>{metaTag.title}</title>
@@ -41,6 +52,15 @@ export const DefaultLayout: FC<Props> = ({ metaTag, children }) => (
       <meta name="msapplication-TileColor" content="#da532c" />
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
       <meta name="theme-color" content="#ffffff" />
+      <link rel="canonical" href={canonicalLink} />
+      {alternateUrls.map((alternateUrl, index) => (
+        <link
+          rel="alternate"
+          hrefLang={alternateUrl.hreflang}
+          href={alternateUrl.link}
+          key={index}
+        />
+      ))}
     </Head>
     {children}
   </>

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -7,9 +7,9 @@ import {
 import { MarkdownContents } from '../../components';
 import {
   metaTagList,
-  appUrlList,
   languages,
   type Language,
+  i18nUrlList,
 } from '../../features';
 import { useSaveSettingLanguage } from '../../hooks';
 import { DefaultLayout } from '../../layouts';
@@ -49,15 +49,15 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
       : metaTagList(language).privacy;
 
   const canonicalLink =
-    type === 'terms'
-      ? (`${appUrlList.terms}/` as const)
-      : (`${appUrlList.privacy}/` as const);
+    type === 'terms' ? i18nUrlList.terms?.ja : i18nUrlList.privacy?.ja;
 
   const alternateUrls = languages.map((hreflang) => {
+    if (hreflang === 'ja') {
+      return { link: canonicalLink, hreflang };
+    }
+
     const link =
-      hreflang === 'ja'
-        ? canonicalLink
-        : (`${canonicalLink}${hreflang}/` as const);
+      type === 'terms' ? i18nUrlList.terms?.en : i18nUrlList.privacy?.en;
 
     return { link, hreflang };
   });

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -5,7 +5,12 @@ import {
 } from '@nekochans/lgtm-cat-ui';
 
 import { MarkdownContents } from '../../components';
-import { metaTagList, type Language } from '../../features';
+import {
+  metaTagList,
+  appUrlList,
+  languages,
+  type Language,
+} from '../../features';
 import { useSaveSettingLanguage } from '../../hooks';
 import { DefaultLayout } from '../../layouts';
 
@@ -18,6 +23,7 @@ type Props = {
   enMarkdown: string;
 };
 
+// eslint-disable-next-line max-lines-per-function
 export const TermsOrPrivacyTemplate: FC<Props> = ({
   type,
   language,
@@ -42,8 +48,26 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
       ? metaTagList(language).terms
       : metaTagList(language).privacy;
 
+  const canonicalLink =
+    type === 'terms'
+      ? (`${appUrlList.terms}/` as const)
+      : (`${appUrlList.privacy}/` as const);
+
+  const alternateUrls = languages.map((hreflang) => {
+    const link =
+      hreflang === 'ja'
+        ? canonicalLink
+        : (`${canonicalLink}${hreflang}/` as const);
+
+    return { link, hreflang };
+  });
+
   return (
-    <DefaultLayout metaTag={metaTag}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgTermsOrPrivacyTemplate
         type={type}
         language={selectedLanguage}

--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -8,8 +8,8 @@ import { MarkdownContents } from '../../components';
 import {
   metaTagList,
   languages,
-  type Language,
   i18nUrlList,
+  type Language,
 } from '../../features';
 import { useSaveSettingLanguage } from '../../hooks';
 import { DefaultLayout } from '../../layouts';

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -5,9 +5,9 @@ import {
   metaTagList,
   appBaseUrl,
   languages,
-  appUrlList,
   type Language,
   LgtmImage,
+  i18nUrlList,
 } from '../../features';
 import { useSaveSettingLanguage, useCatImagesFetcher } from '../../hooks';
 import { DefaultLayout } from '../../layouts';
@@ -25,13 +25,10 @@ const fetchRandomCatImagesCallback = sendClickTopFetchRandomCatButton;
 
 const fetchNewArrivalCatImagesCallback = sendClickTopFetchNewArrivalCatButton;
 
-const canonicalLink = `${appUrlList.top}/` as const;
+const canonicalLink = i18nUrlList.top?.ja;
 
 const alternateUrls = languages.map((hreflang) => {
-  const link =
-    hreflang === 'ja'
-      ? canonicalLink
-      : (`${canonicalLink}${hreflang}/` as const);
+  const link = hreflang === 'ja' ? canonicalLink : i18nUrlList.top?.en;
 
   return { link, hreflang };
 });

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -5,9 +5,9 @@ import {
   metaTagList,
   appBaseUrl,
   languages,
+  i18nUrlList,
   type Language,
   LgtmImage,
-  i18nUrlList,
 } from '../../features';
 import { useSaveSettingLanguage, useCatImagesFetcher } from '../../hooks';
 import { DefaultLayout } from '../../layouts';

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -4,6 +4,8 @@ import { InternalServerErrorImage } from '../../components';
 import {
   metaTagList,
   appBaseUrl,
+  languages,
+  appUrlList,
   type Language,
   LgtmImage,
 } from '../../features';
@@ -23,6 +25,17 @@ const fetchRandomCatImagesCallback = sendClickTopFetchRandomCatButton;
 
 const fetchNewArrivalCatImagesCallback = sendClickTopFetchNewArrivalCatButton;
 
+const canonicalLink = `${appUrlList.top}/` as const;
+
+const alternateUrls = languages.map((hreflang) => {
+  const link =
+    hreflang === 'ja'
+      ? canonicalLink
+      : (`${canonicalLink}${hreflang}/` as const);
+
+  return { link, hreflang };
+});
+
 type Props = {
   language: Language;
   lgtmImages: LgtmImage[];
@@ -37,7 +50,11 @@ export const TopTemplate: FC<Props> = ({ language, lgtmImages }) => {
     useCatImagesFetcher();
 
   return (
-    <DefaultLayout metaTag={metaTag}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgTopTemplate
         language={language}
         lgtmImages={lgtmImages}

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -4,9 +4,9 @@ import Image from 'next/image';
 import {
   metaTagList,
   appBaseUrl,
-  appUrlList,
   languages,
   type Language,
+  i18nUrlList,
 } from '../../features';
 import {
   useSaveSettingLanguage,
@@ -28,13 +28,10 @@ const CatImage = () => (
   <Image src={cat.src} width="302px" height="302px" alt="Cat" priority={true} />
 );
 
-const canonicalLink = `${appUrlList.upload}/` as const;
+const canonicalLink = i18nUrlList.upload?.ja;
 
 const alternateUrls = languages.map((hreflang) => {
-  const link =
-    hreflang === 'ja'
-      ? canonicalLink
-      : (`${canonicalLink}${hreflang}/` as const);
+  const link = hreflang === 'ja' ? canonicalLink : i18nUrlList.upload?.en;
 
   return { link, hreflang };
 });

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,7 +1,13 @@
 import { UploadTemplate as OrgUploadTemplate } from '@nekochans/lgtm-cat-ui';
 import Image from 'next/image';
 
-import { metaTagList, appBaseUrl, type Language } from '../../features';
+import {
+  metaTagList,
+  appBaseUrl,
+  appUrlList,
+  languages,
+  type Language,
+} from '../../features';
 import {
   useSaveSettingLanguage,
   useCatImageValidator,
@@ -22,6 +28,17 @@ const CatImage = () => (
   <Image src={cat.src} width="302px" height="302px" alt="Cat" priority={true} />
 );
 
+const canonicalLink = `${appUrlList.upload}/` as const;
+
+const alternateUrls = languages.map((hreflang) => {
+  const link =
+    hreflang === 'ja'
+      ? canonicalLink
+      : (`${canonicalLink}${hreflang}/` as const);
+
+  return { link, hreflang };
+});
+
 type Props = {
   language: Language;
 };
@@ -36,7 +53,11 @@ export const UploadTemplate: FC<Props> = ({ language }) => {
   const { imageUploader } = useCatImageUploader(language);
 
   return (
-    <DefaultLayout metaTag={metaTag}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgUploadTemplate
         language={language}
         imageValidator={imageValidator}

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -5,8 +5,8 @@ import {
   metaTagList,
   appBaseUrl,
   languages,
-  type Language,
   i18nUrlList,
+  type Language,
 } from '../../features';
 import {
   useSaveSettingLanguage,


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/198

# 関連 URL

- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/
- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/en
- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/upload
- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/en/upload
- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/terms
- https://lgtm-cat-frontend-git-feature-issue198-nekochans.vercel.app/en/terms/

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/198 のDoneの定義を満たしている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

Search Console上で重複コンテンツのエラーが出ているので、以下を参考に `altrenate` タグと `canonical` を追加。

- https://technical-seo.jp/hreflang/
- https://seopack.jp/internal-seo/crawler-measures/multilingual-site-hreflang.php#i-2

ちなみにインデックスが不要なページに関しては何も対応を行っていない。

# レビュアーに重点的にチェックして欲しい点

Slackで話しをした通り、とりあえず言語メニューの仕様は変えないで、altrenateタグとcanonicalタグで回避する方向で進めたよ！検索順位への影響があるから先にマージするけど何かあればマージした後でもコメントもらえると:pray:

# 補足情報

検索順位への悪化があるので早めにマージ、デプロイを行う。