### PR TITLE
トップページに CatRandomCopyButton を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^1.0.1",
+        "@nekochans/lgtm-cat-ui": "^1.1.0",
         "@sentry/nextjs": "^7.12.1",
         "lodash.throttle": "^4.1.1",
         "next": "^12.3.0",
@@ -3515,9 +3515,9 @@
       }
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/1.0.1/eee1aec2aa45f99d34958296da69c20779f49dd5",
-      "integrity": "sha512-Bbkrg8yaj6lRpXEG6A7PoRRIi5/zFf91RSAOg3AS/uzUvHAs8KMsmtyLB/OG/lebjCyUyxdEIl5qQ9f+YjJolw==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/1.1.0/49760a9e0f33d6dc7f8fd17be831188c8d9b315e",
+      "integrity": "sha512-gln+Ow2PJT31Q5Czg47djKs1UEqr1EN6B3/Lm6Fa5WM9JCNzjhb1ZXdk7qWg7vHho0Y7Zq2lohKhgXT0j4eQMA==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^12.3.0",
@@ -33582,9 +33582,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "1.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/1.0.1/eee1aec2aa45f99d34958296da69c20779f49dd5",
-      "integrity": "sha512-Bbkrg8yaj6lRpXEG6A7PoRRIi5/zFf91RSAOg3AS/uzUvHAs8KMsmtyLB/OG/lebjCyUyxdEIl5qQ9f+YjJolw==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/1.1.0/49760a9e0f33d6dc7f8fd17be831188c8d9b315e",
+      "integrity": "sha512-gln+Ow2PJT31Q5Czg47djKs1UEqr1EN6B3/Lm6Fa5WM9JCNzjhb1ZXdk7qWg7vHho0Y7Zq2lohKhgXT0j4eQMA==",
       "requires": {}
     },
     "@next/env": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^1.0.1",
+    "@nekochans/lgtm-cat-ui": "^1.1.0",
     "@sentry/nextjs": "^7.12.1",
     "lodash.throttle": "^4.1.1",
     "next": "^12.3.0",

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -14,6 +14,7 @@ import { DefaultLayout } from '../../layouts';
 import {
   sendClickTopFetchNewArrivalCatButton,
   sendClickTopFetchRandomCatButton,
+  sendCopyMarkdownFromRandomButton,
   sendCopyMarkdownFromTopImages,
 } from '../../utils';
 
@@ -24,6 +25,8 @@ const clipboardMarkdownCallback = sendCopyMarkdownFromTopImages;
 const fetchRandomCatImagesCallback = sendClickTopFetchRandomCatButton;
 
 const fetchNewArrivalCatImagesCallback = sendClickTopFetchNewArrivalCatButton;
+
+const catRandomCopyCallback = sendCopyMarkdownFromRandomButton;
 
 const canonicalLink = i18nUrlList.top?.ja;
 
@@ -63,6 +66,7 @@ export const TopTemplate: FC<Props> = ({ language, lgtmImages }) => {
         fetchNewArrivalCatImagesCallback={fetchNewArrivalCatImagesCallback}
         clipboardMarkdownCallback={clipboardMarkdownCallback}
         changeLanguageCallback={saveSettingLanguage}
+        catRandomCopyCallback={catRandomCopyCallback}
       />
     </DefaultLayout>
   );

--- a/src/utils/gtm.ts
+++ b/src/utils/gtm.ts
@@ -73,3 +73,9 @@ export const sendCopyMarkdownFromCopyButton = (): void => {
     event: 'CopyMarkdownFromCopyButton',
   });
 };
+
+export const sendCopyMarkdownFromRandomButton = (): void => {
+  window.dataLayer.push({
+    event: 'CopyMarkdownFromRandomButton',
+  });
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/197

# 関連 URL

- https://lgtm-cat-frontend-git-feature-issue197-nekochans.vercel.app/

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/197 のDoneの定義を満たしている事

# Storybook の URL もしくはスクリーンショット

## before

<img width="903" alt="before" src="https://user-images.githubusercontent.com/11032365/192077950-599c4d44-e048-424c-9aa6-52d72bf99bf4.png">

## after

<img width="932" alt="after" src="https://user-images.githubusercontent.com/11032365/192078100-633aefd7-dbf4-49f7-8e14-6d50993bb981.png">

# 変更点概要

表題の通り。

`CatRandomCopyButton ` 押下時のイベントは `CopyMarkdownFromRandomButton` でGA上で確認出来るように設定済。

`CatRandomCopyButton` 押下時の詳しい仕様に関しては https://github.com/nekochans/lgtm-cat-ui/pull/188 を参照。

端的に言うと `CatRandomCopyButton` を押下した際に表示されているLGTMイメージの中からRandomで1件Copyする仕様。

より厳密にやろうとすると、Buttonの押下毎にRandomでねこ画像を取得してCopyされるLGTM画像を変更するのが良さそう。

GAを見て `CatRandomCopyButton` がたくさん押されているようであれば、上記の方向で改修を実施する。

# レビュアーに重点的にチェックして欲しい点

https://github.com/nekochans/lgtm-cat-ui/pull/188 も含めて方針問題ないか確認してもらえると:pray:

# 補足情報

特になし