### PR TITLE
styled-componentsで生成されたComponentの命名規則を変更

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,13 @@
     "project": ["./tsconfig.json"],
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "jsx-a11y", "react", "react-hooks"],
+  "plugins": [
+    "@typescript-eslint",
+    "jsx-a11y",
+    "react",
+    "react-hooks",
+    "styled-components-varname"
+  ],
   "rules": {
     "padding-line-between-statements": [
       "error",
@@ -118,7 +124,8 @@
         }
       }
     ],
-    "react/display-name": "off"
+    "react/display-name": "off",
+    "styled-components-varname/varname": 2
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.4",
+        "eslint-plugin-styled-components-varname": "^1.0.1",
         "jest": "^29.0.3",
         "jest-environment-jsdom": "^29.0.3",
         "jest-fetch-mock": "^3.0.3",
@@ -16006,6 +16007,27 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-styled-components-varname": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-varname/-/eslint-plugin-styled-components-varname-1.0.1.tgz",
+      "integrity": "sha512-W4wUa3ZqhpgFNY98UCnI+CNdOsuqh2zv2m5ZZNs9U4zymdOAmZEQfT/pmKF+qqWSsjoGg/XFl81Go7vrpJBeBw==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "~1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-styled-components-varname/node_modules/requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/eslint-scope": {
@@ -43266,6 +43288,23 @@
           "requires": {
             "lodash": "^4.17.15"
           }
+        }
+      }
+    },
+    "eslint-plugin-styled-components-varname": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-styled-components-varname/-/eslint-plugin-styled-components-varname-1.0.1.tgz",
+      "integrity": "sha512-W4wUa3ZqhpgFNY98UCnI+CNdOsuqh2zv2m5ZZNs9U4zymdOAmZEQfT/pmKF+qqWSsjoGg/XFl81Go7vrpJBeBw==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      },
+      "dependencies": {
+        "requireindex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+          "integrity": "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.4",
+    "eslint-plugin-styled-components-varname": "^1.0.1",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "jest-fetch-mock": "^3.0.3",

--- a/src/components/MarkdownContents/MarkdownContents.tsx
+++ b/src/components/MarkdownContents/MarkdownContents.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const _Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -24,7 +24,7 @@ export type Props = {
 };
 
 export const MarkdownContents: FC<Props> = ({ markdown }) => (
-  <Wrapper className="markdown">
+  <_Wrapper className="markdown">
     <ReactMarkdown>{markdown}</ReactMarkdown>
-  </Wrapper>
+  </_Wrapper>
 );


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/208

# 関連 URL

なし

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/208 のDoneの定義を満たしている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

`styled-components` の `styled.div` などで生成されたComponentと通常のComponentの区別が分かりにくいので、`styled-components` で作られたComponentは `_` から命名するように変更。

これらをLinterでチェックする為 `eslint-plugin-styled-components-varname` を追加してESLintでチェック出来るようにした。

# レビュアーに重点的にチェックして欲しい点

特になし https://github.com/nekochans/lgtm-cat-ui/pull/209 とほぼ同じ内容。

# 補足情報

https://github.com/nekochans/lgtm-cat-ui/pull/209 でやった内容と同じ。

プロジェクトの性質上、Componentがほとんど実装されていないので修正箇所は少なめ。