### PR TITLE
@nekochans/lgtm-cat-uiにv2.0.9に変更、next/future/imageを利用するように変更

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -28,6 +28,16 @@ const customViewports = {
   },
 };
 
+// https://github.com/RyanClementsHax/storybook-addon-next/issues/99#issuecomment-1247073410 に記載してある暫定対応を実施
+// https://github.com/RyanClementsHax/storybook-addon-next/pull/121 がマージされたら不要になるハズ
+import Image from 'next/future/image';
+
+const OriginalImage = Image.default;
+Object.defineProperty(Image, 'default', {
+  configurable: true,
+  value: (props) => <OriginalImage {...props} unoptimized />,
+});
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,16 @@ const moduleExports = {
   reactStrictMode: true,
   images: {
     domains: ['lgtm-images.lgtmeow.com', 'stg-lgtm-images.lgtmeow.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'lgtm-images.lgtmeow.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'stg-lgtm-images.lgtmeow.com',
+      },
+    ],
   },
   compiler: {
     styledComponents: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^2.0.8",
+        "@nekochans/lgtm-cat-ui": "^2.0.9",
         "@sentry/nextjs": "^7.12.1",
         "lodash.throttle": "^4.1.1",
         "next": "^12.3.0",
@@ -75,7 +75,7 @@
     },
     "../lgtm-cat-ui": {
       "name": "@nekochans/lgtm-cat-ui",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "extraneous": true,
       "license": "MIT",
       "devDependencies": {
@@ -3626,9 +3626,9 @@
       }
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "2.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.0.8/68db40e6cad9880cb32bf1ed48a25e0443302057",
-      "integrity": "sha512-iBu2vz6kUWya8T4w51NDDRbTT9FknLVX0LPbyHVT5E3jsHBF6+oZCnwqGNyTiYxt5439l6iuuO8rXH+5UagV6A==",
+      "version": "2.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.0.9/54269d36bd52062b21840fb8f895a751a1387e76",
+      "integrity": "sha512-vasnw1uJdaQOnxVCfDi4OeW0xUbjoQFkUsSSeIVU1px8NYsslpOp3QAXVc0lxI3jozhayaW0Frpz3Ilu1DsM9w==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^12.3.1",
@@ -33643,9 +33643,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "2.0.8",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.0.8/68db40e6cad9880cb32bf1ed48a25e0443302057",
-      "integrity": "sha512-iBu2vz6kUWya8T4w51NDDRbTT9FknLVX0LPbyHVT5E3jsHBF6+oZCnwqGNyTiYxt5439l6iuuO8rXH+5UagV6A==",
+      "version": "2.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.0.9/54269d36bd52062b21840fb8f895a751a1387e76",
+      "integrity": "sha512-vasnw1uJdaQOnxVCfDi4OeW0xUbjoQFkUsSSeIVU1px8NYsslpOp3QAXVc0lxI3jozhayaW0Frpz3Ilu1DsM9w==",
       "requires": {}
     },
     "@next/env": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^2.0.8",
+    "@nekochans/lgtm-cat-ui": "^2.0.9",
     "@sentry/nextjs": "^7.12.1",
     "lodash.throttle": "^4.1.1",
     "next": "^12.3.0",

--- a/src/README.md
+++ b/src/README.md
@@ -41,7 +41,7 @@ UI Component は [@nekochans/lgtm-cat-ui](https://github.com/nekochans/lgtm-cat-
 
 Component の内部で React hooks を利用する事は問題ありません。
 
-一部 `next/image` に依存しているものがありますが、将来的にこれは別のディレクトリに移動させるかもしれません。
+一部 `next/future/image` に依存しているものがありますが、将来的にこれは別のディレクトリに移動させるかもしれません。
 
 基本方針のところにも書きましたが、基本的に UI Component は [@nekochans/lgtm-cat-ui](https://github.com/nekochans/lgtm-cat-ui) で開発します。
 

--- a/src/components/ErrorCatImages/InternalServerErrorImage.tsx
+++ b/src/components/ErrorCatImages/InternalServerErrorImage.tsx
@@ -1,13 +1,14 @@
 import type { FC } from 'react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import internalServerError from './images/internal_server_error.webp';
 
 export const InternalServerErrorImage: FC = () => (
   <Image
     src={internalServerError.src}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="500 Internal Server Error"
     priority={true}
   />

--- a/src/components/ErrorCatImages/NotFoundImage.tsx
+++ b/src/components/ErrorCatImages/NotFoundImage.tsx
@@ -1,13 +1,14 @@
 import type { FC } from 'react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import notFound from './images/not_found.webp';
 
 export const NotFoundImage: FC = () => (
   <Image
     src={notFound.src}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="404 Not Found"
     priority={true}
   />

--- a/src/components/ErrorCatImages/ServiceUnavailableImage.tsx
+++ b/src/components/ErrorCatImages/ServiceUnavailableImage.tsx
@@ -1,13 +1,14 @@
 import type { FC } from 'react';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import serviceUnavailable from './images/service_unavailable.webp';
 
 export const ServiceUnavailableImage: FC = () => (
   <Image
     src={serviceUnavailable.src}
-    layout="fill"
-    objectFit="contain"
+    style={{ objectFit: 'contain' }}
+    sizes="100vw"
+    fill
     alt="503 Service Unavailable"
     priority={true}
   />

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { UploadTemplate as OrgUploadTemplate } from '@nekochans/lgtm-cat-ui';
-import Image from 'next/image';
+import Image from 'next/future/image';
 
 import {
   metaTagList,
@@ -20,7 +20,7 @@ import {
 import cat from './images/cat.webp';
 
 const CatImage = () => (
-  <Image src={cat.src} width="302px" height="302px" alt="Cat" priority={true} />
+  <Image src={cat.src} width={302} height={302} alt="Cat" priority={true} />
 );
 
 const canonicalLink = i18nUrlList.upload?.ja;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/68

https://github.com/nekochans/lgtm-cat-frontend/issues/195

# 関連 URL

https://lgtm-cat-frontend-git-feature-upgrade-lgtm-cat-23d120-nekochans.vercel.app

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/195 のDoneの定義を満たしている事

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-eeuuimxbqe.chromatic.com/

# 変更点概要

`@nekochans/lgtm-cat-ui` が内部的に `next/future/image` を利用するようになったので、こちらも合わせて `next/future/image` を利用するように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

https://github.com/nekochans/lgtm-cat-frontend/issues/195 があった事を忘れてしまっており、ブランチ名の命名規則がいつもと違う。（今度から注意する。）