### PR TITLE
Biuld時間短縮の為、swcMinifyを有効化

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,7 @@ const moduleExports = {
     defaultLocale: 'ja',
     localeDetection: false,
   },
+  swcMinify: true,
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/215

# 関連 URL

特になし

# Done の定義

- `next.config.js` の `swcMinify` の有効化が行われている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

`swcMinify` の有効化を実施。

ただBuild時間の計測を行ったが対して変わらなかった。Component数が増えてくると差が出てくるのだと思われる。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし