### PR TITLE
StorybookのViewportに実際に使われているスマホのサイズを追加

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,13 @@ import { initialize, mswDecorator } from 'msw-storybook-addon';
 initialize();
 
 const customViewports = {
+  iPhone11ProMax: {
+    name: 'iPhone 11 Pro Max',
+    styles: {
+      width: '414px',
+      height: '896px',
+    },
+  },
   iPhone12: {
     name: 'iPhone 12 Pro',
     styles: {
@@ -12,11 +19,39 @@ const customViewports = {
       height: '844px',
     },
   },
-  GooglePixel: {
+  iPhone13ProMax: {
+    name: 'iPhone 13 Pro Max',
+    styles: {
+      width: '428px',
+      height: '926px',
+    },
+  },
+  googlePixel3: {
     name: 'Google Pixel 3',
     styles: {
       width: '411px',
       height: '823px',
+    },
+  },
+  googlePixel5: {
+    name: 'Google Pixel 5',
+    styles: {
+      width: '393px',
+      height: '851px',
+    },
+  },
+  iPadMini: {
+    name: 'iPad mini 2〜5',
+    styles: {
+      width: '768px',
+      height: '1024px',
+    },
+  },
+  iPadMini6: {
+    name: 'iPad mini 6',
+    styles: {
+      width: '744px',
+      height: '1133px',
     },
   },
   iPadPro11: {


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/211

# 関連 URL

- Storybookの修正なのでStorybookのURLを参照

# Done の定義

- https://github.com/nekochans/lgtm-cat-frontend/issues/211 のDoneの定義を満たしている事

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-ypuugcgbie.chromatic.com/

# 変更点概要

StorybookのViewportに実際に使われているスマホでの確認を行う為によく利用されているデバイスを追加。

内容的には https://github.com/nekochans/lgtm-cat-ui/pull/222 で対応した内容と同じ。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
