### PR TITLE
重複コンテンツ回避の為、SEO対策

### DIFF
--- a/src/features/metaTag.ts
+++ b/src/features/metaTag.ts
@@ -31,6 +31,17 @@ export const customErrorTitle = (language: Language): string => {
   }
 };
 
+const topPageTitle = (language: Language): string => {
+  switch (language) {
+    case 'ja':
+      return `${defaultTitle} 猫好きのためのLGTM画像共有サービス`;
+    case 'en':
+      return `${defaultTitle} | LGTM image share service for cat lovers`;
+    default:
+      return assertNever(language);
+  }
+};
+
 const uploadPageTitle = (language: Language): string => {
   switch (language) {
     case 'ja':
@@ -100,7 +111,7 @@ type MetaTagList = {
 
 export const metaTagList = (language: Language): MetaTagList => ({
   top: {
-    title: `${defaultTitle} | LGTM image share service for cat lovers`,
+    title: topPageTitle(language),
     ogpImgUrl: appUrlList.ogpImg,
     ogpTargetUrl: appUrlList.top,
     appName,

--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -23,6 +23,11 @@ export const DefaultLayout: FC<Props> = ({
       <title>{metaTag.title}</title>
       <meta charSet="utf-8" />
       <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      {metaTag.description != null ? (
+        <meta name="description" content={metaTag.description} />
+      ) : (
+        ''
+      )}
       <meta property="og:title" content={metaTag.title} />
       <meta property="og:description" content={metaTag.description} />
       <meta property="og:type" content="website" />


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/223

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue223-nekochans.vercel.app/

# Done の定義

- トップページに `description` タグが追加されている事
- titleが英語と日本語で別の物になっている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

翻訳を行っているのに `/` と `/en` が重複コンテンツ扱いになってしまっている現象を解消する為に以下の対応を実施。

- トップページに `description` タグがなかったので追加
- titleを英語と日本語でそれぞれ別々の物を設定するように変更

# レビュアーに重点的にチェックして欲しい点

方針問題ないかと、`description`, `title` が問題ないか確認してもらえると:pray:

# 補足情報

特になし
