### PR TITLE
canonicalタグの追加

### DIFF
--- a/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -6,6 +6,7 @@ import type { Language, MetaTag, Url } from '../../features';
 type Props = {
   metaTag: MetaTag;
   children: ReactNode;
+  canonicalLink?: Url;
   alternateUrls?: Array<{
     hreflang: Language;
     link?: Url;
@@ -16,6 +17,7 @@ type Props = {
 export const DefaultLayout: FC<Props> = ({
   metaTag,
   children,
+  canonicalLink,
   alternateUrls,
 }) => (
   <>
@@ -55,6 +57,11 @@ export const DefaultLayout: FC<Props> = ({
       <meta name="msapplication-TileColor" content="#da532c" />
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
       <meta name="theme-color" content="#ffffff" />
+      {canonicalLink != null ? (
+        <link rel="canonical" href={canonicalLink} />
+      ) : (
+        ''
+      )}
       {alternateUrls?.map((alternateUrl, index) => (
         <link
           rel="alternate"

--- a/src/templates/TopTemplate/TopTemplate.tsx
+++ b/src/templates/TopTemplate/TopTemplate.tsx
@@ -27,10 +27,8 @@ const fetchNewArrivalCatImagesCallback = sendClickTopFetchNewArrivalCatButton;
 
 const catRandomCopyCallback = sendCopyMarkdownFromRandomButton;
 
-const canonicalLink = i18nUrlList.top?.ja;
-
 const alternateUrls = languages.map((hreflang) => {
-  const link = hreflang === 'ja' ? canonicalLink : i18nUrlList.top?.en;
+  const link = hreflang === 'ja' ? i18nUrlList.top?.ja : i18nUrlList.top?.en;
 
   return { link, hreflang };
 });
@@ -43,11 +41,18 @@ type Props = {
 export const TopTemplate: FC<Props> = ({ language, lgtmImages }) => {
   const metaTag = metaTagList(language).top;
 
+  const canonicalLink =
+    language === 'en' ? i18nUrlList.top?.en : i18nUrlList.top?.ja;
+
   const { randomCatImagesFetcher, newArrivalCatImagesFetcher } =
     useCatImagesFetcher();
 
   return (
-    <DefaultLayout metaTag={metaTag} alternateUrls={alternateUrls}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgTopTemplate
         language={language}
         lgtmImages={lgtmImages}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/225

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue225add-canonical-nekochans.vercel.app/

# Done の定義

- トップページにcanonicalタグが追加されている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

トップページにcanonicalタグを追加、日本語と英語のページでそれぞれ以下のようになる。

## 日本語のトップページ

```
<link rel="canonical" href="https://lgtmeow.com/">
<link rel="alternate" hreflang="en" href="https://lgtmeow.com/en/">
<link rel="alternate" hreflang="ja" href="https://lgtmeow.com/">
```

## 英語のトップページ

```
<link rel="canonical" href="https://lgtmeow.com/en/">
<link rel="alternate" hreflang="en" href="https://lgtmeow.com/en/">
<link rel="alternate" hreflang="ja" href="https://lgtmeow.com/">
```

ちなみにトップページ以外のページにもcanonicalを追加しようと思ったが、現時点ではちゃんとインデックスに登録されているので一旦トップページだけ対応した。

# レビュアーに重点的にチェックして欲しい点

方針問題ないか確認してもらえると:pray:

# 補足情報

特になし