### PR TITLE
インデックスさせたいページはcanonicalタグを追加するように変更

### DIFF
--- a/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
+++ b/src/templates/TermsOrPrivacyTemplate/TermsOrPrivacyTemplate.tsx
@@ -13,12 +13,49 @@ import {
   type Language,
 } from '../../features';
 import { DefaultLayout } from '../../layouts';
+import { assertNever } from '../../utils';
 
 type Props = {
   type: TemplateType;
   language: Language;
   jaMarkdown: string;
   enMarkdown: string;
+};
+
+const createCanonicalLink = (type: TemplateType, language: Language) => {
+  switch (type) {
+    case 'terms':
+      return language === 'en' ? i18nUrlList.terms?.en : i18nUrlList.terms?.ja;
+    case 'privacy':
+      return language === 'en'
+        ? i18nUrlList.privacy?.en
+        : i18nUrlList.privacy?.ja;
+    default:
+      return assertNever(type);
+  }
+};
+
+const createAlternateUrls = (type: TemplateType) => {
+  switch (type) {
+    case 'terms':
+      return languages.map((hreflang) => {
+        if (hreflang === 'en') {
+          return { link: i18nUrlList.terms?.en, hreflang };
+        }
+
+        return { link: i18nUrlList.terms?.ja, hreflang };
+      });
+    case 'privacy':
+      return languages.map((hreflang) => {
+        if (hreflang === 'en') {
+          return { link: i18nUrlList.privacy?.en, hreflang };
+        }
+
+        return { link: i18nUrlList.privacy?.ja, hreflang };
+      });
+    default:
+      return assertNever(type);
+  }
 };
 
 // eslint-disable-next-line max-lines-per-function
@@ -38,22 +75,16 @@ export const TermsOrPrivacyTemplate: FC<Props> = ({
       ? metaTagList(language).terms
       : metaTagList(language).privacy;
 
-  const canonicalLink =
-    type === 'terms' ? i18nUrlList.terms?.ja : i18nUrlList.privacy?.ja;
+  const canonicalLink = createCanonicalLink(type, language);
 
-  const alternateUrls = languages.map((hreflang) => {
-    if (hreflang === 'ja') {
-      return { link: canonicalLink, hreflang };
-    }
-
-    const link =
-      type === 'terms' ? i18nUrlList.terms?.en : i18nUrlList.privacy?.en;
-
-    return { link, hreflang };
-  });
+  const alternateUrls = createAlternateUrls(type);
 
   return (
-    <DefaultLayout metaTag={metaTag} alternateUrls={alternateUrls}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgTermsOrPrivacyTemplate
         type={type}
         language={language}

--- a/src/templates/UploadTemplate/UploadTemplate.tsx
+++ b/src/templates/UploadTemplate/UploadTemplate.tsx
@@ -23,14 +23,6 @@ const CatImage = () => (
   <Image src={cat.src} width={302} height={302} alt="Cat" priority={true} />
 );
 
-const canonicalLink = i18nUrlList.upload?.ja;
-
-const alternateUrls = languages.map((hreflang) => {
-  const link = hreflang === 'ja' ? canonicalLink : i18nUrlList.upload?.en;
-
-  return { link, hreflang };
-});
-
 type Props = {
   language: Language;
 };
@@ -38,12 +30,26 @@ type Props = {
 export const UploadTemplate: FC<Props> = ({ language }) => {
   const metaTag = metaTagList(language).upload;
 
+  const canonicalLink =
+    language === 'en' ? i18nUrlList.upload?.en : i18nUrlList.upload?.ja;
+
+  const alternateUrls = languages.map((hreflang) => {
+    const link =
+      hreflang === 'en' ? i18nUrlList.upload?.en : i18nUrlList.upload?.ja;
+
+    return { link, hreflang };
+  });
+
   const { imageValidator } = useCatImageValidator(language);
 
   const { imageUploader } = useCatImageUploader(language);
 
   return (
-    <DefaultLayout metaTag={metaTag} alternateUrls={alternateUrls}>
+    <DefaultLayout
+      metaTag={metaTag}
+      canonicalLink={canonicalLink}
+      alternateUrls={alternateUrls}
+    >
       <OrgUploadTemplate
         language={language}
         imageValidator={imageValidator}


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/232

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue232add-cano-9b99aa-nekochans.vercel.app/

# Done の定義

- トップ以外のページにもcanonicalタグが追加されている事

# Storybook の URL もしくはスクリーンショット

UI変更はないのでなし。

# 変更点概要

トップページの重複コンテンツはcanonicalタグで回避出来たので（https://github.com/nekochans/lgtm-cat-frontend/pull/226 の対応）他のページにもcanonicalタグを追加。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし