### PR TITLE
next/link の legacyBehavior を利用しない形に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^2.2.0",
+        "@nekochans/lgtm-cat-ui": "^2.2.1",
         "@sentry/nextjs": "^7.23.0",
         "lodash.throttle": "^4.1.1",
         "next": "^13.0.6",
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@jest/console/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2558,9 +2558,9 @@
       }
     },
     "node_modules/@jest/core/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2717,9 +2717,9 @@
       }
     },
     "node_modules/@jest/environment/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2832,9 +2832,9 @@
       }
     },
     "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -2920,9 +2920,9 @@
       }
     },
     "node_modules/@jest/globals/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3215,9 +3215,9 @@
       }
     },
     "node_modules/@jest/test-result/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@jest/test-sequencer/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.0/8516139fc1258c7e2611c742fb9fa1b39693a8e6",
-      "integrity": "sha512-zjoC8EkAPwBNaJvQk4URgpFn96qGmvoBawo90Bwt7vR8NcD/45j7otltUytLih8uvG3DTz8QFitGlOKxSj/vwQ==",
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.1/af90d7eb21c0d36109c6832abd923630ae1af4a9",
+      "integrity": "sha512-yyqSycPd+yR4CiCtgb6j6pylXCRrn6GlOfL4bJD2bSSZORZIKjSn4PKdtQ+0txhbS8AOZJ7+//I+OfflFKBTXA==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^13.0.6",
@@ -11987,9 +11987,9 @@
       }
     },
     "node_modules/babel-jest/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -16682,9 +16682,9 @@
       }
     },
     "node_modules/expect/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -19695,9 +19695,9 @@
       }
     },
     "node_modules/jest-circus/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -19820,9 +19820,9 @@
       }
     },
     "node_modules/jest-cli/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -19924,9 +19924,9 @@
       }
     },
     "node_modules/jest-config/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20115,9 +20115,9 @@
       }
     },
     "node_modules/jest-each/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20233,9 +20233,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20323,9 +20323,9 @@
       }
     },
     "node_modules/jest-environment-node/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20574,9 +20574,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20770,9 +20770,9 @@
       }
     },
     "node_modules/jest-resolve/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -20921,9 +20921,9 @@
       }
     },
     "node_modules/jest-runner/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21102,9 +21102,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21302,9 +21302,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21511,9 +21511,9 @@
       }
     },
     "node_modules/jest-validate/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21616,9 +21616,9 @@
       }
     },
     "node_modules/jest-watcher/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21690,9 +21690,9 @@
       }
     },
     "node_modules/jest-worker/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -21776,9 +21776,9 @@
       }
     },
     "node_modules/jest/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -25314,9 +25314,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -29594,9 +29594,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/@types/yargs": {
-      "version": "17.0.16",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-      "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+      "version": "17.0.17",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+      "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -32998,9 +32998,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33106,9 +33106,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33234,9 +33234,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33327,9 +33327,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33399,9 +33399,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33514,9 +33514,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33637,9 +33637,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33684,9 +33684,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -33979,9 +33979,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.0/8516139fc1258c7e2611c742fb9fa1b39693a8e6",
-      "integrity": "sha512-zjoC8EkAPwBNaJvQk4URgpFn96qGmvoBawo90Bwt7vR8NcD/45j7otltUytLih8uvG3DTz8QFitGlOKxSj/vwQ=="
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.1/af90d7eb21c0d36109c6832abd923630ae1af4a9",
+      "integrity": "sha512-yyqSycPd+yR4CiCtgb6j6pylXCRrn6GlOfL4bJD2bSSZORZIKjSn4PKdtQ+0txhbS8AOZJ7+//I+OfflFKBTXA=="
     },
     "@next/env": {
       "version": "13.0.6",
@@ -40410,9 +40410,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -44034,9 +44034,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46235,9 +46235,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46307,9 +46307,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46401,9 +46401,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46480,9 +46480,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46631,9 +46631,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46721,9 +46721,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46795,9 +46795,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -46997,9 +46997,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47130,9 +47130,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47275,9 +47275,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47429,9 +47429,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47596,9 +47596,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47761,9 +47761,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47843,9 +47843,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -47904,9 +47904,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -50538,9 +50538,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "pretty-error": {
@@ -53806,9 +53806,9 @@
           }
         },
         "@types/yargs": {
-          "version": "17.0.16",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.16.tgz",
-          "integrity": "sha512-Mh3OP0oh8X7O7F9m5AplC+XHYLBWuPKNkGVD3gIZFLFebBnuFI2Nz5Sf8WLvwGxECJ8YjifQvFdh79ubODkdug==",
+          "version": "17.0.17",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+          "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^2.2.0",
+    "@nekochans/lgtm-cat-ui": "^2.2.1",
     "@sentry/nextjs": "^7.23.0",
     "lodash.throttle": "^4.1.1",
     "next": "^13.0.6",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/234

# 関連 URL



# Done の定義

- `@nekochans/lgtm-cat-ui` が最新に更新され `next/link` の `legacyBehavior` を利用しない形に変更

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-pksdpzgfrv.chromatic.com/

# 変更点概要

https://github.com/nekochans/lgtm-cat-ui/pull/238 で `next/link` の `legacyBehavior` を利用しない形に変更したので `@nekochans/lgtm-cat-ui` を最新にアップグレード。

動作確認後特に問題は起きてない。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし