### PR TITLE
@nekochans/lgtm-cat-ui のバージョンを最新安定版の v2.2.7 にアップグレード

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lgtm-cat-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@nekochans/lgtm-cat-ui": "^2.2.1",
+        "@nekochans/lgtm-cat-ui": "^2.2.7",
         "@sentry/nextjs": "^7.23.0",
         "lodash.throttle": "^4.1.1",
         "next": "^13.0.6",
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/@nekochans/lgtm-cat-ui": {
-      "version": "2.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.1/af90d7eb21c0d36109c6832abd923630ae1af4a9",
-      "integrity": "sha512-yyqSycPd+yR4CiCtgb6j6pylXCRrn6GlOfL4bJD2bSSZORZIKjSn4PKdtQ+0txhbS8AOZJ7+//I+OfflFKBTXA==",
+      "version": "2.2.7",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.7/1068d051a8752f523bf10096e3d2acccfeacdc13",
+      "integrity": "sha512-q2dfQCf5VTNOzyw4XDMnp05VSwjmOEIT1Jb8Vohvy09L4w2Z3JAibXXYzb59JdP6aL4YkN16TLfGnp9v0/lWUA==",
       "license": "MIT",
       "peerDependencies": {
         "next": "^13.0.6",
@@ -25074,9 +25074,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "funding": [
         {
@@ -33979,9 +33979,9 @@
       }
     },
     "@nekochans/lgtm-cat-ui": {
-      "version": "2.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.1/af90d7eb21c0d36109c6832abd923630ae1af4a9",
-      "integrity": "sha512-yyqSycPd+yR4CiCtgb6j6pylXCRrn6GlOfL4bJD2bSSZORZIKjSn4PKdtQ+0txhbS8AOZJ7+//I+OfflFKBTXA=="
+      "version": "2.2.7",
+      "resolved": "https://npm.pkg.github.com/download/@nekochans/lgtm-cat-ui/2.2.7/1068d051a8752f523bf10096e3d2acccfeacdc13",
+      "integrity": "sha512-q2dfQCf5VTNOzyw4XDMnp05VSwjmOEIT1Jb8Vohvy09L4w2Z3JAibXXYzb59JdP6aL4YkN16TLfGnp9v0/lWUA=="
     },
     "@next/env": {
       "version": "13.0.6",
@@ -50379,9 +50379,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
-      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "dependencies": {
-    "@nekochans/lgtm-cat-ui": "^2.2.1",
+    "@nekochans/lgtm-cat-ui": "^2.2.7",
     "@sentry/nextjs": "^7.23.0",
     "lodash.throttle": "^4.1.1",
     "next": "^13.0.6",

--- a/src/features/result.ts
+++ b/src/features/result.ts
@@ -1,17 +1,38 @@
-import {
-  createSuccessResult as orgCreateSuccessResult,
-  createFailureResult as orgCreateFailureResult,
-  isSuccessResult as orgIsSuccessResult,
-  isFailureResult as orgIsFailureResult,
-  Result as OrgResult,
-} from '@nekochans/lgtm-cat-ui';
+export const SuccessMarker = 'SuccessMarker';
+export const FailureMarker = 'FailureMarker';
 
-export type Result<T, E> = OrgResult<T, E>;
+export type SuccessResult<T> = { value: T; _: typeof SuccessMarker };
+export type FailureResult<E> = { value: E; _: typeof FailureMarker };
+export type Result<T, E> = SuccessResult<T> | FailureResult<E>;
 
-export const createSuccessResult = orgCreateSuccessResult;
+export const createSuccessResult = <T>(value: T): SuccessResult<T> => ({
+  value,
+  // eslint-disable-next-line id-length
+  _: SuccessMarker,
+});
 
-export const createFailureResult = orgCreateFailureResult;
+export const createFailureResult = <E>(value: E): FailureResult<E> => ({
+  value,
+  // eslint-disable-next-line id-length
+  _: FailureMarker,
+});
 
-export const isSuccessResult = orgIsSuccessResult;
+export const isSuccessResult = <T>(
+  result: Result<unknown, unknown>
+): result is SuccessResult<T> => {
+  if ('_' in result) {
+    return result._ === SuccessMarker;
+  }
 
-export const isFailureResult = orgIsFailureResult;
+  return false;
+};
+
+export const isFailureResult = <T>(
+  result: Result<unknown, unknown>
+): result is FailureResult<T> => {
+  if ('_' in result) {
+    return result._ === FailureMarker;
+  }
+
+  return false;
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-ui/issues/240

# 関連 URL

https://lgtm-cat-frontend-git-feature-upgrade-lgtm-cat-ui-nekochans.vercel.app

# Done の定義

- `@nekochans/lgtm-cat-ui` のバージョンが最新安定版に更新されている事

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-jbqacnwnlf.chromatic.com/

# 変更点概要

`@nekochans/lgtm-cat-ui` のバージョンを最新安定版に更新。

外から見た時の変更点はないが、Package内のBuildをVite4.0系で行われるようになったのと、Packageのファイル形式がESModuleだけになった点。

ESModuleになった関係でJestのテストが上手く動作しなくなってしまい色々試行錯誤したが、改修範囲が大きそうなので、Result型などは `@nekochans/lgtm-cat-ui` に依存しない形に変更した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし