### PR TITLE
カスタムErrorの定義方法を変更

### DIFF
--- a/src/features/errors/FetchLgtmImagesError.ts
+++ b/src/features/errors/FetchLgtmImagesError.ts
@@ -1,11 +1,5 @@
 export class FetchLgtmImagesError extends Error {
-  constructor(error?: string) {
-    super(error);
-    this.name = new.target.name;
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  static {
+    this.prototype.name = 'FetchLgtmImagesError';
   }
 }

--- a/src/features/errors/IsAcceptableCatImageError.ts
+++ b/src/features/errors/IsAcceptableCatImageError.ts
@@ -1,11 +1,5 @@
 export class IsAcceptableCatImageError extends Error {
-  constructor(error?: string) {
-    super(error);
-    this.name = new.target.name;
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  static {
+    this.prototype.name = 'IsAcceptableCatImageError';
   }
 }

--- a/src/features/errors/UploadCatImageError.ts
+++ b/src/features/errors/UploadCatImageError.ts
@@ -1,11 +1,5 @@
 export class UploadCatImageError extends Error {
-  constructor(error?: string) {
-    super(error);
-    this.name = new.target.name;
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  static {
+    this.prototype.name = 'UploadCatImageError';
   }
 }

--- a/src/features/errors/UploadCatImageSizeTooLargeError.ts
+++ b/src/features/errors/UploadCatImageSizeTooLargeError.ts
@@ -1,11 +1,5 @@
 export class UploadCatImageSizeTooLargeError extends Error {
-  constructor(error?: string) {
-    super(error);
-    this.name = new.target.name;
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  static {
+    this.prototype.name = 'UploadCatImageSizeTooLargeError';
   }
 }

--- a/src/features/errors/UploadCatImageValidationError.ts
+++ b/src/features/errors/UploadCatImageValidationError.ts
@@ -1,11 +1,5 @@
 export class UploadCatImageValidationError extends Error {
-  constructor(error?: string) {
-    super(error);
-    this.name = new.target.name;
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
+  static {
+    this.prototype.name = 'UploadCatImageValidationError';
   }
 }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/249

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue249custom-error-nekochans.vercel.app/

# このPRで対応すること / このPRで対応しないこと

カスタムエラーの定義方法を以下の記事を参考に修正する。

https://www.wantedly.com/companies/wantedly/post_articles/492456

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-vjxvbibbea.chromatic.com/

# 変更点概要

カスタムErrorの定義方法を以下の記事に合わせて変更。

https://www.wantedly.com/companies/wantedly/post_articles/492456

`this.prototype.name` に代入する事でコードをminifyしたときに代入した値が変化しないようにする。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし