### PR TITLE
メンテナンスモードをVercel Edge Configから取得するように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env*.local
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -99,7 +99,28 @@ asdf local nodejs 18.12.1
 
 ## メンテナンスモードについて
 
-`IS_IN_MAINTENANCE` が `1` の場合はメンテナンスページを強制的に表示します。
+[Vercel Edge Config](https://vercel.com/docs/storage/edge-config) を利用してメンテナンスモードを実現しています。
+
+以下から Vercel Edge Config を編集可能です。
+
+https://vercel.com/nekochans/lgtm-cat-frontend/stores
+
+それぞれ以下のように対応しています。
+
+- `lgtm-cat-frontend-store` （本番用）
+- `stg-lgtm-cat-frontend-store` （ローカルを含む開発、ステージング用）
+
+<img width="1416" alt="VercelEdgeConfig" src="https://github.com/nekochans/lgtm-cat-frontend/assets/11032365/7cf65e37-9009-4a79-b039-8f9353ec5c54">
+
+メンテナンスモードに移行する為には `isInMaintenance` を `true` に変更します。
+
+編集後は「Save」を押下するか `Command + s` で保存しないと反映されません。
+
+<img width="1415" alt="VercelEdgeConfigEdit" src="https://github.com/nekochans/lgtm-cat-frontend/assets/11032365/e61c7ff4-ded5-4e42-9ce9-0be2abb371bc">
+
+メンテナンスモードになると全てのページでメンテナンス中を示すエラーページが表示されます。
+
+<img width="887" alt="isInMaintenance" src="https://github.com/nekochans/lgtm-cat-frontend/assets/11032365/0350f584-8876-4df7-833d-fdcf0dda99cd">
 
 ## 開発でよく使うコマンド
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ NEXT_PUBLIC_APP_ENV=local
 NEXT_PUBLIC_APP_URL=本アプリケーションのURL、ローカルの場合は http://localhost:2222
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-から始まるGoogle Tag ManagerのIDを指定
 NEXT_PUBLIC_LGTMEOW_BFF_URL=https://github.com/nekochans/lgtm-cat-bff が稼働しているURLを指定
-IS_IN_MAINTENANCE=0
+EDGE_CONFIG=Vercel Edge ConfigのURL（Vercel上の値を参照）
 ```
 
 以下の環境変数はテストコード実行時や Build 時に参照されるので [direnv](https://github.com/direnv/direnv) を使って `.envrc` を配置するのが良いです。

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@nekochans/lgtm-cat-ui": "^3.0.2",
         "@sentry/nextjs": "^7.91.0",
+        "@vercel/edge-config": "^0.4.1",
         "lodash.throttle": "^4.1.1",
         "next": "^14.0.4",
         "react": "^18.2.0",
@@ -8017,6 +8018,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@vercel/edge-config": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-0.4.1.tgz",
+      "integrity": "sha512-4Mc3H7lE+x4RrL17nY8CWeEorvJHbkNbQTy9p8H1tO7y11WeKj5xeZSr07wNgfWInKXDUwj5FZ3qd/jIzjPxug==",
+      "dependencies": {
+        "@vercel/edge-config-fs": "0.1.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
@@ -29872,6 +29889,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "@vercel/edge-config": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-0.4.1.tgz",
+      "integrity": "sha512-4Mc3H7lE+x4RrL17nY8CWeEorvJHbkNbQTy9p8H1tO7y11WeKj5xeZSr07wNgfWInKXDUwj5FZ3qd/jIzjPxug==",
+      "requires": {
+        "@vercel/edge-config-fs": "0.1.0"
+      }
+    },
+    "@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@nekochans/lgtm-cat-ui": "^3.0.2",
     "@sentry/nextjs": "^7.91.0",
+    "@vercel/edge-config": "^0.4.1",
     "lodash.throttle": "^4.1.1",
     "next": "^14.0.4",
     "react": "^18.2.0",

--- a/src/edge/maintenance.ts
+++ b/src/edge/maintenance.ts
@@ -1,2 +1,7 @@
-export const isInMaintenance = (): boolean =>
-  process.env.IS_IN_MAINTENANCE === '1';
+import { get } from '@vercel/edge-config';
+
+export const isInMaintenance = async (): Promise<boolean> => {
+  const isInMaintenanceMode = await get<boolean>('isInMaintenance');
+
+  return isInMaintenanceMode === true;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,7 @@ export const config = {
   matcher: ['/', '/upload', '/terms', '/privacy', '/maintenance'],
 };
 
-export const middleware: NextMiddleware = (req: NextRequest) => {
+export const middleware: NextMiddleware = async (req: NextRequest) => {
   const { nextUrl } = req;
 
   if (isBanCountry(req)) {
@@ -18,7 +18,8 @@ export const middleware: NextMiddleware = (req: NextRequest) => {
     return NextResponse.rewrite(nextUrl);
   }
 
-  if (isInMaintenance()) {
+  const isInMaintenanceMode = await isInMaintenance();
+  if (isInMaintenanceMode) {
     nextUrl.pathname = '/maintenance';
 
     return NextResponse.rewrite(nextUrl);


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/273

# 関連 URL

なし

# このPRで対応すること / このPRで対応しないこと

Vercel Edge Configを利用したメンテナンスモードを実装する。

https://github.com/nekochans/lgtm-cat-frontend/issues/273 のDoneの定義を満たす実装は全てこのPR内で対応する。

# Storybook の URL もしくはスクリーンショット

なし

# 変更点概要

[Vercel Edge Config](https://vercel.com/docs/storage/edge-config#) を利用したメンテナンスモードを実装。

Vercel Edge Config は開発・ステージング用と本番用の2種類を用意した。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

不要になった環境変数 `IS_IN_MAINTENANCE ` はこのPRがデプロイされたらVercel上から削除する。
