### PR TITLE
国コードの取得を VercelConfig を使った形に変更

### DIFF
--- a/src/edge/country.ts
+++ b/src/edge/country.ts
@@ -1,43 +1,13 @@
+import { get } from '@vercel/edge-config';
 import { type NextRequest } from 'next/server';
 
-const bannedCountryCodeList = [
-  'BE',
-  'BG',
-  'CZ',
-  'DK',
-  'DD',
-  'DE',
-  'EE',
-  'GB',
-  'IE',
-  'GR',
-  'ES',
-  'FR',
-  'FX',
-  'GF',
-  'HR',
-  'IT',
-  'CY',
-  'LV',
-  'LT',
-  'LU',
-  'HU',
-  'MT',
-  'NL',
-  'AT',
-  'PL',
-  'PT',
-  'RO',
-  'SI',
-  'SK',
-  'FI',
-  'SE',
-];
-
-export const isBanCountry = (req: NextRequest): boolean => {
-  const country = req.geo?.country?.toUpperCase();
-  if (country != null) {
-    return bannedCountryCodeList.includes(country);
+export const isBanCountry = async (req: NextRequest): Promise<boolean> => {
+  const bannedCountryCodeList = await get<string[]>('bannedCountryCodeList');
+  if (bannedCountryCodeList) {
+    const country = req.geo?.country?.toUpperCase();
+    if (country != null) {
+      return bannedCountryCodeList.includes(country);
+    }
   }
 
   return false;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,8 @@ export const config = {
 export const middleware: NextMiddleware = async (req: NextRequest) => {
   const { nextUrl } = req;
 
-  if (isBanCountry(req)) {
+  const isBanCountryResult = await isBanCountry(req);
+  if (isBanCountryResult) {
     nextUrl.pathname = '/api/errors';
 
     return NextResponse.rewrite(nextUrl);


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/274

# 関連 URL

https://lgtm-cat-frontend-git-feature-issue274banned-c-95f985-nekochans.vercel.app/

# このPRで対応すること / このPRで対応しないこと

https://github.com/nekochans/lgtm-cat-frontend/issues/274 のDoneの定義を満たす為の実装は全てこのPRで実装します。

# Storybook の URL もしくはスクリーンショット

なし

# 変更点概要

タイトルの通り、今まではハードコードしていたがデプロイが必要になってしまうのでVercel Configから取得するように変更。

これでデプロイなしで変更が可能になった。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし