### PR TITLE
全てのブランチでCIが動作するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,10 @@
 name: ci
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
   push:
     branches:
-      - main
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
# issueURL

なし

# 関連 URL

なし

# このPRで対応すること / このPRで対応しないこと

全てのブランチに対する `git push` でCI用のWorkflowが動作するように修正する。

# Storybook の URL もしくはスクリーンショット

なし

# 変更点概要

タイトルの通り。大きめの機能の場合は直接 `main` にマージしないでreleaseブランチを作成していく開発スタイルを取るので、全てのブランチでCIが動作するように修正を実施した。

ついでに任意のブランチやタグでCIを手動実行出来るように `workflow_dispatch:` も追加した。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

なし