### PR TITLE
App RouterでSentryの設定を有効にした

### DIFF
--- a/src/app/en/error.tsx
+++ b/src/app/en/error.tsx
@@ -3,6 +3,7 @@
 import { httpStatusCode } from '@/constants';
 import { isIncludeLanguageAppPath } from '@/features';
 import { ErrorTemplate } from '@/templates';
+import * as Sentry from '@sentry/nextjs';
 import { usePathname } from 'next/navigation';
 import { useEffect, type JSX } from 'react';
 
@@ -13,7 +14,7 @@ type Props = {
 
 const Error = ({ error }: Props): JSX.Element => {
   useEffect(() => {
-    console.error(error);
+    Sentry.captureException(error);
   }, [error]);
 
   const language = 'en';

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,6 +3,7 @@
 import { httpStatusCode } from '@/constants';
 import { isIncludeLanguageAppPath } from '@/features';
 import { ErrorTemplate } from '@/templates';
+import * as Sentry from '@sentry/nextjs';
 import { usePathname } from 'next/navigation';
 import { useEffect, type JSX } from 'react';
 
@@ -13,7 +14,7 @@ type Props = {
 
 const Error = ({ error }: Props): JSX.Element => {
   useEffect(() => {
-    console.error(error);
+    Sentry.captureException(error);
   }, [error]);
 
   const language = 'ja';

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { httpStatusCode } from '@/constants';
+import * as Sentry from '@sentry/nextjs';
+import NextError from 'next/error';
+import { useEffect, type JSX } from 'react';
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+const GlobalError = ({ error }: Props): JSX.Element => {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body>
+        <NextError statusCode={httpStatusCode.internalServerError} />
+      </body>
+    </html>
+  );
+};
+
+export default GlobalError;


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/292

# 関連 URL

https://vercel.live/open-feedback/lgtm-cat-frontend-git-feature-issue292sentry-nekochans.vercel.app?via=pr-comment-visit-preview-link&passThrough=1

# このPRで対応すること / このPRで対応しないこと

エラー発生時にSentry上にエラーレポートが送信されるようにする。

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-xqxeedxssq.chromatic.com/

# 変更点概要

以下のドキュメントを参考に Sentry.captureException を明示的にコールするように変更。

https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし