### PR TITLE
Chromatic へのデプロイワークフローのタイムアウトを延長

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,7 +6,7 @@ jobs:
   chromatic-deployment:
     name: Deploy Storybook to chromatic
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/257

# 関連 URL

なし

# このPRで対応すること / このPRで対応しないこと

https://github.com/nekochans/lgtm-cat-frontend/issues/257 の完了の定義を満たす実装は全てこのPRで対応する。

# Storybook の URL もしくはスクリーンショット

なし

# 変更点概要

たまにChromaticでタイムアウトが発生するのでタイムアウトを延長。

# レビュアーに重点的にチェックして欲しい点

なし

# 補足情報

なし
