### PR TITLE
新デザイン（2024年）のFooterComponentを作成

### DIFF
--- a/src/app/_components/Footer.stories.tsx
+++ b/src/app/_components/Footer.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Footer } from './Footer';
+
+const meta = {
+  component: Footer,
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ShowJapanese: Story = {
+  args: {
+    language: 'ja',
+  },
+};
+
+export const ShowEnglish: Story = {
+  args: {
+    language: 'en',
+  },
+};

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -10,6 +10,9 @@ export type Props = {
   language: Language;
 };
 
+const linkStyle =
+  'text-[#43281E] font-inter text-sm font-normal leading-5 hover:underline';
+
 export const Footer = ({ language }: Props): JSX.Element => {
   const terms = createTermsOfUseLinksFromLanguages(language);
 
@@ -19,19 +22,31 @@ export const Footer = ({ language }: Props): JSX.Element => {
     createExternalTransmissionPolicyLinksFromLanguages(language);
 
   return (
-    <footer>
-      <Link href={terms.link} prefetch={false}>
-        <Text data-gtm-click="footer-terms-link">{terms.text}</Text>
-      </Link>
-      <Link href={privacy.link} prefetch={false}>
-        <Text data-gtm-click="footer-privacy-link">{privacy.text}</Text>
-      </Link>
-      <Link href={externalTransmissionPolicy.link} prefetch={false}>
-        <Text data-gtm-click="footer-external-transmission-policy-link">
-          {externalTransmissionPolicy.text}
+    <footer className="flex w-full flex-col">
+      <div className="mx-auto flex w-full max-w-[375px] items-center px-0 py-3 md:hidden">
+        <div className="flex flex-1 flex-col items-center justify-center gap-2">
+          <Link href={terms.link} prefetch={false} className={linkStyle}>
+            <Text data-gtm-click="footer-terms-link">{terms.text}</Text>
+          </Link>
+          <Link href={privacy.link} prefetch={false} className={linkStyle}>
+            <Text data-gtm-click="footer-privacy-link">{privacy.text}</Text>
+          </Link>
+          <Link
+            href={externalTransmissionPolicy.link}
+            prefetch={false}
+            className={linkStyle}
+          >
+            <Text data-gtm-click="footer-external-transmission-policy-link">
+              {externalTransmissionPolicy.text}
+            </Text>
+          </Link>
+        </div>
+      </div>
+      <div className="flex h-[60px] items-center justify-center self-stretch border-t border-orange-200 bg-orange-50">
+        <Text className="font-inter text-base font-medium text-orange-800">
+          Copyright (c) nekochans
         </Text>
-      </Link>
-      <Text>Copyright (c) nekochans</Text>
+      </div>
     </footer>
   );
 };

--- a/src/app/_components/Footer.tsx
+++ b/src/app/_components/Footer.tsx
@@ -1,0 +1,37 @@
+import { createExternalTransmissionPolicyLinksFromLanguages } from '@/features/externalTransmissionPolicy';
+import type { Language } from '@/features/language';
+import { createPrivacyPolicyLinksFromLanguages } from '@/features/privacyPolicy';
+import { createTermsOfUseLinksFromLanguages } from '@/features/termsOfUse';
+import Link from 'next/link';
+import type { JSX } from 'react';
+import { Text } from 'react-aria-components';
+
+export type Props = {
+  language: Language;
+};
+
+export const Footer = ({ language }: Props): JSX.Element => {
+  const terms = createTermsOfUseLinksFromLanguages(language);
+
+  const privacy = createPrivacyPolicyLinksFromLanguages(language);
+
+  const externalTransmissionPolicy =
+    createExternalTransmissionPolicyLinksFromLanguages(language);
+
+  return (
+    <footer>
+      <Link href={terms.link} prefetch={false}>
+        <Text data-gtm-click="footer-terms-link">{terms.text}</Text>
+      </Link>
+      <Link href={privacy.link} prefetch={false}>
+        <Text data-gtm-click="footer-privacy-link">{privacy.text}</Text>
+      </Link>
+      <Link href={externalTransmissionPolicy.link} prefetch={false}>
+        <Text data-gtm-click="footer-external-transmission-policy-link">
+          {externalTransmissionPolicy.text}
+        </Text>
+      </Link>
+      <Text>Copyright (c) nekochans</Text>
+    </footer>
+  );
+};

--- a/src/features/externalTransmissionPolicy.ts
+++ b/src/features/externalTransmissionPolicy.ts
@@ -1,0 +1,29 @@
+import { type Language } from '@/features/language';
+import { createIncludeLanguageAppPath } from '@/features/url';
+import { assertNever } from '@/utils/assertNever';
+import type { LinkAttribute } from './linkAttribute';
+
+export const createExternalTransmissionPolicyLinksFromLanguages = (
+  language: Language,
+): LinkAttribute => {
+  switch (language) {
+    case 'en':
+      return {
+        text: 'External Transmission Policy',
+        link: createIncludeLanguageAppPath(
+          'external-transmission-policy',
+          language,
+        ),
+      };
+    case 'ja':
+      return {
+        text: '外部送信ポリシー',
+        link: createIncludeLanguageAppPath(
+          'external-transmission-policy',
+          language,
+        ),
+      };
+    default:
+      return assertNever(language);
+  }
+};

--- a/src/features/linkAttribute.ts
+++ b/src/features/linkAttribute.ts
@@ -1,0 +1,6 @@
+import type { IncludeLanguageAppPath } from '@/features/url';
+
+export type LinkAttribute = {
+  text: string;
+  link: IncludeLanguageAppPath;
+};

--- a/src/features/privacyPolicy.ts
+++ b/src/features/privacyPolicy.ts
@@ -1,0 +1,23 @@
+import { type Language } from '@/features/language';
+import { createIncludeLanguageAppPath } from '@/features/url';
+import { assertNever } from '@/utils/assertNever';
+import type { LinkAttribute } from './linkAttribute';
+
+export const createPrivacyPolicyLinksFromLanguages = (
+  language: Language,
+): LinkAttribute => {
+  switch (language) {
+    case 'en':
+      return {
+        text: 'Privacy Policy',
+        link: createIncludeLanguageAppPath('privacy', language),
+      };
+    case 'ja':
+      return {
+        text: 'プライバシーポリシー',
+        link: createIncludeLanguageAppPath('privacy', language),
+      };
+    default:
+      return assertNever(language);
+  }
+};

--- a/src/features/termsOfUse.ts
+++ b/src/features/termsOfUse.ts
@@ -1,0 +1,23 @@
+import { type Language } from '@/features/language';
+import { createIncludeLanguageAppPath } from '@/features/url';
+import { assertNever } from '@/utils/assertNever';
+import type { LinkAttribute } from './linkAttribute';
+
+export const createTermsOfUseLinksFromLanguages = (
+  language: Language,
+): LinkAttribute => {
+  switch (language) {
+    case 'en':
+      return {
+        text: 'Terms of Use',
+        link: createIncludeLanguageAppPath('terms', language),
+      };
+    case 'ja':
+      return {
+        text: '利用規約',
+        link: createIncludeLanguageAppPath('terms', language),
+      };
+    default:
+      return assertNever(language);
+  }
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/323

# 関連 URL

StorybookでComponentを作成しただけなのでなし。

# このPRで対応すること / このPRで対応しないこと

Footer用のComponentを実装する。

# Storybook の URL もしくはスクリーンショット

https://622b6c5dc31e9e003a111eb5-ujshxglbjj.chromatic.com/?path=/story/app-components-footer--show-japanese

# 変更点概要

FooterComponentを作成。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし