### PR TITLE
/en/upload のcanonical指定が間違っていたので修正

### DIFF
--- a/src/app/(default)/en/upload/page.tsx
+++ b/src/app/(default)/en/upload/page.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   },
   metadataBase: new URL(appBaseUrl()),
   alternates: {
-    canonical: i18nUrlList.upload.ja,
+    canonical: i18nUrlList.upload.en,
     languages: {
       ja: i18nUrlList.upload.ja,
       en: i18nUrlList.upload.en,


### PR DESCRIPTION
# issueURL

#384

# このPRで対応すること / このPRで対応しないこと

## 対応すること

- `/en/upload` ページの canonical URL を正しい英語ページURL (`i18nUrlList.upload.en`) に修正

## 対応しないこと

- 他のページのcanonical設定の確認・修正 (必要であれば別issueで対応)

# 変更点概要

英語版アップロードページ (`/en/upload`) の canonical URL が誤って日本語ページ (`i18nUrlList.upload.ja`) を指定していました。

この設定ミスにより、検索エンジンが英語ページを日本語ページの複製と判断する可能性がありました。正しく英語ページのURL (`i18nUrlList.upload.en`) を指定するよう修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 英語版アップロードページの言語設定メタデータを修正しました。ページが正しい言語バージョンとして認識されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->