### PR TITLE
MCPドキュメントにStreamable HTTPトランスポートを追加

### DIFF
--- a/src/features/docs/__tests__/functions/mcp-text.test.ts
+++ b/src/features/docs/__tests__/functions/mcp-text.test.ts
@@ -48,10 +48,14 @@ describe("src/features/docs/functions/mcp-text.ts getMcpTexts TestCases", () => 
     );
   });
 
-  it("should return 3 client config patterns", () => {
+  it("should return 2 transports with correct patterns", () => {
     const result = getMcpTexts("ja");
 
-    expect(result.clientConfig.patterns).toHaveLength(3);
+    expect(result.clientConfig.transports).toHaveLength(2);
+    // Streamable HTTP: 3 patterns
+    expect(result.clientConfig.transports[0].patterns).toHaveLength(3);
+    // SSE: 3 patterns
+    expect(result.clientConfig.transports[1].patterns).toHaveLength(3);
   });
 
   it("should return 2 GitHub Actions examples", () => {
@@ -62,10 +66,14 @@ describe("src/features/docs/functions/mcp-text.ts getMcpTexts TestCases", () => 
     expect(result.githubActions.examples[1].title).toContain("Codex");
   });
 
-  it("should include correct server URL in client config", () => {
+  it("should include correct server URLs in client config", () => {
     const result = getMcpTexts("ja");
 
-    expect(result.clientConfig.intro.serverUrl).toBe(
+    expect(result.clientConfig.intro.serverUrls).toHaveLength(2);
+    expect(result.clientConfig.intro.serverUrls[0].url).toBe(
+      "https://api.lgtmeow.com/mcp"
+    );
+    expect(result.clientConfig.intro.serverUrls[1].url).toBe(
       "https://api.lgtmeow.com/sse"
     );
   });

--- a/src/features/docs/code-examples/mcp/codex-auto-review.yml
+++ b/src/features/docs/code-examples/mcp/codex-auto-review.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
-      - name: Install mcp-proxy for SSE bridge
+      - name: Install mcp-proxy for HTTP bridge
         run: pip install mcp-proxy
 
       - name: Run Codex
@@ -36,7 +36,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           codex-args: |
-            --config mcp_servers={"lgtmeow"={"command"="mcp-proxy","args"=["https://api.lgtmeow.com/sse"]}}
+            --config mcp_servers={"lgtmeow"={"command"="mcp-proxy","args"=["https://api.lgtmeow.com/mcp","--transport=streamablehttp"]}}
           prompt: |
             リポジトリ: ${{ github.repository }}
             PR番号: ${{ github.event.pull_request.number }}

--- a/src/features/docs/code-examples/mcp/mcp-servers.json
+++ b/src/features/docs/code-examples/mcp/mcp-servers.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "lgtmeow": {
-      "type": "sse",
-      "url": "https://api.lgtmeow.com/sse"
+      "type": "http",
+      "url": "https://api.lgtmeow.com/mcp"
     }
   }
 }

--- a/src/features/docs/components/docs-mcp-page.tsx
+++ b/src/features/docs/components/docs-mcp-page.tsx
@@ -297,11 +297,16 @@ export function DocsMcpPage({
                 【{texts.clientConfig.intro.serverUrlTitle}】
               </p>
               {texts.clientConfig.intro.serverUrls.map((serverUrl) => (
-                <div className="flex items-center gap-2" key={serverUrl.url}>
-                  <span className="text-orange-700 text-sm">
+                <div
+                  className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2"
+                  key={serverUrl.url}
+                >
+                  <span className="shrink-0 text-orange-700 text-sm">
                     {serverUrl.label}:
                   </span>
-                  <CodeSnippet code={serverUrl.url} variant="inline" />
+                  <div className="min-w-0">
+                    <CodeSnippet code={serverUrl.url} variant="inline" />
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/features/docs/components/docs-mcp-page.tsx
+++ b/src/features/docs/components/docs-mcp-page.tsx
@@ -11,6 +11,7 @@ import {
   type McpConfigPattern,
   type McpGitHubActionsExample,
   type McpToolInfo,
+  type McpTransportSection,
 } from "@/features/docs/functions/mcp-text";
 import type { Language } from "@/features/language";
 import type { IncludeLanguageAppPath } from "@/features/url";
@@ -102,12 +103,38 @@ interface ConfigPatternSectionProps {
  */
 function ConfigPatternSection({ pattern, index }: ConfigPatternSectionProps) {
   return (
-    <SubSection title={`${index + 1}. ${pattern.title}`}>
+    <div className="flex flex-col gap-2">
+      <h4 className="font-medium text-orange-700">
+        {index + 1}. {pattern.title}
+      </h4>
       {pattern.description && <p>{pattern.description}</p>}
       <CodeSnippet code={pattern.code} language="json" />
       {pattern.note && (
         <p className="text-orange-700 text-sm">{pattern.note}</p>
       )}
+    </div>
+  );
+}
+
+interface TransportSectionProps {
+  readonly transport: McpTransportSection;
+}
+
+/**
+ * トランスポート別のセクションを表示するコンポーネント
+ */
+function TransportSection({ transport }: TransportSectionProps) {
+  return (
+    <SubSection title={transport.title}>
+      <div className="flex flex-col gap-4">
+        {transport.patterns.map((pattern, index) => (
+          <ConfigPatternSection
+            index={index}
+            key={pattern.title}
+            pattern={pattern}
+          />
+        ))}
+      </div>
     </SubSection>
   );
 }
@@ -187,10 +214,19 @@ export function DocsMcpPage({
     ...baseTexts,
     clientConfig: {
       ...baseTexts.clientConfig,
-      patterns: baseTexts.clientConfig.patterns.map((pattern, index) =>
-        index === 0
-          ? { ...pattern, code: externalCodes.mcpServersJson }
-          : pattern
+      transports: baseTexts.clientConfig.transports.map(
+        (transport, transportIndex) =>
+          transportIndex === 0
+            ? {
+                ...transport,
+                // Streamable HTTP セクションの最初のパターン（HTTP直接サポート）に外部コードを注入
+                patterns: transport.patterns.map((pattern, patternIndex) =>
+                  patternIndex === 0
+                    ? { ...pattern, code: externalCodes.mcpServersJson }
+                    : pattern
+                ),
+              }
+            : transport
       ),
     },
     githubActions: {
@@ -247,28 +283,31 @@ export function DocsMcpPage({
         {/* セクション3: MCPクライアントの設定方法 */}
         <Section title={texts.clientConfig.title}>
           <p>{texts.clientConfig.intro.main}</p>
-          <div className="flex flex-col gap-1 rounded-lg bg-orange-50 p-4">
-            <p className="font-medium text-orange-800">
-              【{texts.clientConfig.intro.authTitle}】
-            </p>
-            <p className="text-orange-700 text-sm">
-              {texts.clientConfig.intro.authDescription}
-            </p>
-            <p className="mt-2 font-medium text-orange-800">
-              【{texts.clientConfig.intro.serverUrlTitle}】
-            </p>
-            <CodeSnippet
-              code={texts.clientConfig.intro.serverUrl}
-              variant="inline"
-            />
+          <div className="flex flex-col gap-3 rounded-lg bg-orange-50 p-4">
+            <div className="flex flex-col gap-1">
+              <p className="font-medium text-orange-800">
+                【{texts.clientConfig.intro.authTitle}】
+              </p>
+              <p className="text-orange-700 text-sm">
+                {texts.clientConfig.intro.authDescription}
+              </p>
+            </div>
+            <div className="flex flex-col gap-1">
+              <p className="font-medium text-orange-800">
+                【{texts.clientConfig.intro.serverUrlTitle}】
+              </p>
+              {texts.clientConfig.intro.serverUrls.map((serverUrl) => (
+                <div className="flex items-center gap-2" key={serverUrl.url}>
+                  <span className="text-orange-700 text-sm">
+                    {serverUrl.label}:
+                  </span>
+                  <CodeSnippet code={serverUrl.url} variant="inline" />
+                </div>
+              ))}
+            </div>
           </div>
-          <p className="mt-2">{texts.clientConfig.patternsIntro}</p>
-          {texts.clientConfig.patterns.map((pattern, index) => (
-            <ConfigPatternSection
-              index={index}
-              key={pattern.title}
-              pattern={pattern}
-            />
+          {texts.clientConfig.transports.map((transport) => (
+            <TransportSection key={transport.title} transport={transport} />
           ))}
         </Section>
 

--- a/src/features/docs/functions/mcp-text.ts
+++ b/src/features/docs/functions/mcp-text.ts
@@ -17,6 +17,16 @@ export interface McpConfigPattern {
   readonly title: string;
 }
 
+export interface McpTransportSection {
+  readonly patterns: readonly McpConfigPattern[];
+  readonly title: string;
+}
+
+export interface McpServerUrl {
+  readonly label: string;
+  readonly url: string;
+}
+
 export interface McpGitHubActionsExample {
   readonly description: string;
   readonly folderNote?: string;
@@ -44,10 +54,9 @@ export interface McpTexts {
       readonly authTitle: string;
       readonly authDescription: string;
       readonly serverUrlTitle: string;
-      readonly serverUrl: string;
+      readonly serverUrls: readonly McpServerUrl[];
     };
-    readonly patternsIntro: string;
-    readonly patterns: readonly McpConfigPattern[];
+    readonly transports: readonly McpTransportSection[];
   };
   readonly githubActions: {
     readonly title: string;
@@ -60,24 +69,58 @@ export interface McpTexts {
   };
 }
 
-const mcpServerUrl = "https://api.lgtmeow.com/sse";
+const streamableHttpUrl = "https://api.lgtmeow.com/mcp";
+const sseUrl = "https://api.lgtmeow.com/sse";
 
-const nodeConfigCode = `{
+// Streamable HTTP 用の設定コード（stdio ブリッジ）
+const streamableHttpNodeBridgeCode = `{
   "mcpServers": {
     "lgtmeow": {
       "command": "npx",
-      "args": ["mcp-remote", "${mcpServerUrl}"]
+      "args": ["mcp-remote", "${streamableHttpUrl}"]
     }
   }
 }`;
 
-const pythonConfigCode = `{
+const streamableHttpPythonBridgeCode = `{
   "mcpServers": {
     "lgtmeow": {
       "command": "uvx",
       "args": [
         "mcp-proxy",
-        "${mcpServerUrl}"
+        "${streamableHttpUrl}",
+        "--transport=streamablehttp"
+      ]
+    }
+  }
+}`;
+
+// SSE 用の設定コード
+const sseDirectCode = `{
+  "mcpServers": {
+    "lgtmeow": {
+      "type": "sse",
+      "url": "${sseUrl}"
+    }
+  }
+}`;
+
+const sseNodeBridgeCode = `{
+  "mcpServers": {
+    "lgtmeow": {
+      "command": "npx",
+      "args": ["mcp-remote", "${sseUrl}"]
+    }
+  }
+}`;
+
+const ssePythonBridgeCode = `{
+  "mcpServers": {
+    "lgtmeow": {
+      "command": "uvx",
+      "args": [
+        "mcp-proxy",
+        "${sseUrl}"
       ]
     }
   }
@@ -140,33 +183,69 @@ export function getMcpTexts(language: Language): McpTexts {
         clientConfig: {
           title: "MCPクライアントの設定方法",
           intro: {
-            main: "LGTMeow MCP Server は、リモート(SSE)方式のみ提供しています。",
+            main: "LGTMeow MCP Server は、Streamable HTTP と SSE の2つのトランスポートに対応しています。",
             authTitle: "認証について",
             authDescription:
               "認証不要で利用できます。API キーやトークンの設定は不要です。",
             serverUrlTitle: "サーバー URL",
-            serverUrl: mcpServerUrl,
+            serverUrls: [
+              {
+                label: "Streamable HTTP（推奨）",
+                url: streamableHttpUrl,
+              },
+              {
+                label: "SSE",
+                url: sseUrl,
+              },
+            ],
           },
-          patternsIntro:
-            "お使いの MCP クライアントが SSE を「直接サポートしているか」に応じて、以下の 3 パターンのいずれかを利用してください。",
-          patterns: [
+          transports: [
             {
-              title: "SSE を直接サポートするクライアントの場合",
-              // 実際の値は page.tsx から props として渡される
-              code: "",
+              title: "Streamable HTTP を使う場合（推奨）",
+              patterns: [
+                {
+                  title: "HTTP を直接サポートするクライアントの場合",
+                  // 実際の値は page.tsx から props として渡される
+                  code: "",
+                },
+                {
+                  title: "Node 環境 / mcp-remote を使う場合",
+                  description:
+                    "クライアントが HTTP を直接サポートしない場合、mcp-remote を利用して HTTP → stdio をブリッジできます。",
+                  code: streamableHttpNodeBridgeCode,
+                  note: "npx が見つからない場合は、Node.js がインストールされているか、PATH が通っているかをご確認ください。必要に応じて npx のフルパスを指定してください。",
+                },
+                {
+                  title: "Python / uvx + mcp-proxy を使う場合",
+                  description:
+                    "Python ユーザー向けの HTTP → stdio ブリッジです。",
+                  code: streamableHttpPythonBridgeCode,
+                  note: "uvx が見つからない場合は、インストール状況と PATH をご確認ください。必要に応じて uvx のフルパスを指定してください。",
+                },
+              ],
             },
             {
-              title: "Node 環境 / mcp-remote を使う場合",
-              description:
-                "クライアントが SSE を直接サポートしない場合、mcp-remote を利用して SSE → stdio をブリッジできます。",
-              code: nodeConfigCode,
-              note: "npx が見つからない場合は、Node.js がインストールされているか、PATH が通っているかをご確認ください。必要に応じて npx のフルパスを指定してください。",
-            },
-            {
-              title: "Python / uvx + mcp-proxy を使う場合",
-              description: "Python ユーザー向けの SSE → stdio ブリッジです。",
-              code: pythonConfigCode,
-              note: "uvx が見つからない場合は、インストール状況と PATH をご確認ください。必要に応じて uvx のフルパスを指定してください。",
+              title: "SSE を使う場合",
+              patterns: [
+                {
+                  title: "SSE を直接サポートするクライアントの場合",
+                  code: sseDirectCode,
+                },
+                {
+                  title: "Node 環境 / mcp-remote を使う場合",
+                  description:
+                    "クライアントが SSE を直接サポートしない場合、mcp-remote を利用して SSE → stdio をブリッジできます。",
+                  code: sseNodeBridgeCode,
+                  note: "npx が見つからない場合は、Node.js がインストールされているか、PATH が通っているかをご確認ください。必要に応じて npx のフルパスを指定してください。",
+                },
+                {
+                  title: "Python / uvx + mcp-proxy を使う場合",
+                  description:
+                    "Python ユーザー向けの SSE → stdio ブリッジです。",
+                  code: ssePythonBridgeCode,
+                  note: "uvx が見つからない場合は、インストール状況と PATH をご確認ください。必要に応じて uvx のフルパスを指定してください。",
+                },
+              ],
             },
           ],
         },
@@ -254,33 +333,67 @@ export function getMcpTexts(language: Language): McpTexts {
         clientConfig: {
           title: "MCP Client Configuration",
           intro: {
-            main: "LGTMeow MCP Server only supports remote (SSE) mode.",
+            main: "LGTMeow MCP Server supports two transports: Streamable HTTP and SSE.",
             authTitle: "Authentication",
             authDescription:
               "No authentication required. No API key or token configuration is needed.",
-            serverUrlTitle: "Server URL",
-            serverUrl: mcpServerUrl,
+            serverUrlTitle: "Server URLs",
+            serverUrls: [
+              {
+                label: "Streamable HTTP (Recommended)",
+                url: streamableHttpUrl,
+              },
+              {
+                label: "SSE",
+                url: sseUrl,
+              },
+            ],
           },
-          patternsIntro:
-            "Depending on whether your MCP client directly supports SSE, use one of the following 3 patterns.",
-          patterns: [
+          transports: [
             {
-              title: "For clients that directly support SSE",
-              // 実際の値は page.tsx から props として渡される
-              code: "",
+              title: "Using Streamable HTTP (Recommended)",
+              patterns: [
+                {
+                  title: "For clients that directly support HTTP",
+                  // 実際の値は page.tsx から props として渡される
+                  code: "",
+                },
+                {
+                  title: "Using Node environment / mcp-remote",
+                  description:
+                    "If your client does not directly support HTTP, you can use mcp-remote to bridge HTTP → stdio.",
+                  code: streamableHttpNodeBridgeCode,
+                  note: "If npx is not found, please verify that Node.js is installed and PATH is configured. Specify the full path to npx if needed.",
+                },
+                {
+                  title: "Using Python / uvx + mcp-proxy",
+                  description: "HTTP → stdio bridge for Python users.",
+                  code: streamableHttpPythonBridgeCode,
+                  note: "If uvx is not found, please verify installation and PATH. Specify the full path to uvx if needed.",
+                },
+              ],
             },
             {
-              title: "For Node environment / using mcp-remote",
-              description:
-                "If your client doesn't directly support SSE, you can use mcp-remote to bridge SSE → stdio.",
-              code: nodeConfigCode,
-              note: "If npx is not found, please verify that Node.js is installed and PATH is configured. Specify the full path to npx if needed.",
-            },
-            {
-              title: "For Python / uvx + mcp-proxy",
-              description: "This is an SSE → stdio bridge for Python users.",
-              code: pythonConfigCode,
-              note: "If uvx is not found, please verify installation and PATH. Specify the full path to uvx if needed.",
+              title: "Using SSE",
+              patterns: [
+                {
+                  title: "For clients that directly support SSE",
+                  code: sseDirectCode,
+                },
+                {
+                  title: "Using Node environment / mcp-remote",
+                  description:
+                    "If your client does not directly support SSE, you can use mcp-remote to bridge SSE → stdio.",
+                  code: sseNodeBridgeCode,
+                  note: "If npx is not found, please verify that Node.js is installed and PATH is configured. Specify the full path to npx if needed.",
+                },
+                {
+                  title: "Using Python / uvx + mcp-proxy",
+                  description: "SSE → stdio bridge for Python users.",
+                  code: ssePythonBridgeCode,
+                  note: "If uvx is not found, please verify installation and PATH. Specify the full path to uvx if needed.",
+                },
+              ],
             },
           ],
         },


### PR DESCRIPTION
<!-- (Copilot Review への依頼: レビューコメントは日本語で記載してください -->

# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/466

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲

- MCPドキュメントページにStreamable HTTPトランスポートの設定方法を追加
- サーバーURLを複数表示（Streamable HTTP / SSE）に対応
- トランスポート別にセクションを分離してUIを整理
- GitHub Actions設定例をStreamable HTTPに更新（Claude Code Action / Codex Action）

## 対応しない範囲

- MCPサーバー側の変更（バックエンド側は既にStreamable HTTP対応済み）

# Storybook の URL、 スクリーンショット

https://622b6c5dc31e9e003a111eb5-dhnbzzxjit.chromatic.com/?path=/story/features-docs-docsmcppage--japanese

# 変更点概要

MCPクライアント設定において、Streamable HTTP（推奨）とSSEの2つのトランスポートを選択できるようにしました。

## 主な変更内容

1. **サーバーURL表示の複数対応**
   - Streamable HTTP（推奨）: `https://api.lgtmeow.com/mcp`
   - SSE: `https://api.lgtmeow.com/sse`

2. **トランスポート別セクション分離**
   - 「Streamable HTTP を使う場合（推奨）」セクション
   - 「SSE を使う場合」セクション
   - 各セクションに直接サポート/Node環境/Python環境の設定パターンを配置

3. **GitHub Actions設定の更新**
   - mcp-servers.json: SSE → Streamable HTTP に変更
   - codex-auto-review.yml: SSE → Streamable HTTP に変更

# レビュアーに重点的にチェックして欲しい点

- トランスポート別のUI構造が分かりやすいか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * MCPクライアント設定UIがトランスポート別の表示に対応し、各トランスポートごとのパターンと複数サーバーURLを確認可能になりました。

* **ドキュメント**
  * lgtmeow向けサーバー設定例をSSEからStreamable HTTPへ切替えた設定例とワークフロー表記に更新しました。

* **テスト**
  * クライアント設定出力に合わせてテストの期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->