### PR TITLE
README.mdとcreate-prスキルを改善（Codex対応・PRテンプレート省略禁止ルール追加）

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -97,6 +97,15 @@ git rev-parse --abbrev-ref HEAD
 
 `.github/PULL_REQUEST_TEMPLATE.md` で定義されている構造に従う。各セクションに何を書くかを具体的に整理する。
 
+### 全セクション必須の原則
+
+**テンプレートに記載されているセクションは必ずすべて埋める**。任意とされるセクションでも、空のまま省略してはならない。該当する内容が無い場合は、`〇〇のため記載なし` のように **理由付きで明示的に「なし」と記載する**。
+
+- ❌ NG：該当しないセクションを丸ごと省略する → レビュアーが「書き忘れ」か「該当なし」か判別できない
+- ✅ OK：「README.md のドキュメント変更のみで Component / UI の変更を伴わないため、Storybook 連携は不要」のように、判断の根拠を含めて記載
+
+これは「未来の開発者・レビュアーが PR を初見で読んだ際に、なぜそのセクションが空なのかを判断できる」状態を保つために重要。
+
 ### `# issueURL`（必須）
 
 - 対応する GitHub Issue の URL を **フル URL で** 記載する
@@ -122,12 +131,38 @@ git rev-parse --abbrev-ref HEAD
     - LCP 警告（`priority` 未設定）→ #471
   ```
 
-### `# Storybook の URL、 スクリーンショット`（任意）
+### `# Storybook の URL、 スクリーンショット`（必須・該当なしの場合も理由付きで記載）
 
-- UI 変更がある場合は、以下のいずれかを記載する
-  - Chromatic の Storybook URL（PR ごとに自動生成される）
-  - スクリーンショット（デスクトップ / モバイル両方を別見出しで載せると親切）
-- UI 変更がない場合は、確認した URL を記載する程度でも可（例：「`http://localhost:2222` 表示正常」）
+このセクションは PR 作成時点では空になることが多いが、**省略は禁止**。以下の運用ルールに従って必ず記載する。
+
+#### UI 変更がある場合
+
+PR 作成後、Chromatic ビルドが完了するのを待ってから URL を取得し、`gh pr edit` で説明欄を更新する流れになる。
+
+1. PR を作成する（`gh pr create --draft ...`）
+2. Chromatic CI が走り、Storybook が公開される（数分かかる）
+3. PR の Storybook URL を取得する。以下のいずれかの方法で取得できる
+   - **CLI 経由（AI エージェント向け推奨）**：`gh pr checks <PR番号> --repo <owner>/<repo>` の出力から `Storybook Publish` 行の URL を抽出
+   - **GitHub UI 経由（人間向け）**：PR ページの「All checks have passed」セクションで `Storybook Publish` のリンクをクリック
+   - どちらの方法でも、PR 毎に Chromatic が生成した **公開 Storybook のベース URL** が得られる
+     - 例：`https://622b6c5dc31e9e003a111eb5-vwrshrxnjd.chromatic.com/`
+4. 必要に応じて、特定の Story を指す `?path=/story/<story-id>` を末尾に付ける
+   - 例：`https://622b6c5dc31e9e003a111eb5-cprksiyplm.chromatic.com/?path=/story/features-docs-docsmcppage--japanese`
+5. `gh pr edit <PR番号> --body "..."` で取得した URL を該当セクションに貼り付けて更新
+
+スクリーンショットを併載する場合は、デスクトップ / モバイル の両方を別見出し（H2）で載せると親切。
+
+> 注意：`gh pr checks` の出力には `Deploy Storybook to chromatic` という GitHub Actions ジョブ行（`https://github.com/.../actions/runs/...` 形式）も含まれる。これは **Storybook の URL ではなく CI ジョブの URL** なので混同しないこと。PR 説明欄に書くべきは `Storybook Publish` 行の `*.chromatic.com/` 形式の URL。
+
+#### UI 変更がない場合
+
+「**なし**」とだけ書くのではなく、**なぜ該当しないのか** を理由付きで記載する。
+
+例：
+
+- 「README.md のドキュメント変更のみで Component / UI の変更を伴わないため、Storybook 連携は不要」
+- 「`src/scripts/` 配下の開発用スクリプトの追加のみで、レンダリング対象の Component は含まれないため不要」
+- 「依存 package のバージョン更新のみで、UI 表示への影響は無いため不要」
 
 ### `# 変更点概要`（必須）
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -97,6 +97,15 @@ git rev-parse --abbrev-ref HEAD
 
 `.github/PULL_REQUEST_TEMPLATE.md` で定義されている構造に従う。各セクションに何を書くかを具体的に整理する。
 
+### 全セクション必須の原則
+
+**テンプレートに記載されているセクションは必ずすべて埋める**。任意とされるセクションでも、空のまま省略してはならない。該当する内容が無い場合は、`〇〇のため記載なし` のように **理由付きで明示的に「なし」と記載する**。
+
+- ❌ NG：該当しないセクションを丸ごと省略する → レビュアーが「書き忘れ」か「該当なし」か判別できない
+- ✅ OK：「README.md のドキュメント変更のみで Component / UI の変更を伴わないため、Storybook 連携は不要」のように、判断の根拠を含めて記載
+
+これは「未来の開発者・レビュアーが PR を初見で読んだ際に、なぜそのセクションが空なのかを判断できる」状態を保つために重要。
+
 ### `# issueURL`（必須）
 
 - 対応する GitHub Issue の URL を **フル URL で** 記載する
@@ -122,12 +131,38 @@ git rev-parse --abbrev-ref HEAD
     - LCP 警告（`priority` 未設定）→ #471
   ```
 
-### `# Storybook の URL、 スクリーンショット`（任意）
+### `# Storybook の URL、 スクリーンショット`（必須・該当なしの場合も理由付きで記載）
 
-- UI 変更がある場合は、以下のいずれかを記載する
-  - Chromatic の Storybook URL（PR ごとに自動生成される）
-  - スクリーンショット（デスクトップ / モバイル両方を別見出しで載せると親切）
-- UI 変更がない場合は、確認した URL を記載する程度でも可（例：「`http://localhost:2222` 表示正常」）
+このセクションは PR 作成時点では空になることが多いが、**省略は禁止**。以下の運用ルールに従って必ず記載する。
+
+#### UI 変更がある場合
+
+PR 作成後、Chromatic ビルドが完了するのを待ってから URL を取得し、`gh pr edit` で説明欄を更新する流れになる。
+
+1. PR を作成する（`gh pr create --draft ...`）
+2. Chromatic CI が走り、Storybook が公開される（数分かかる）
+3. PR の Storybook URL を取得する。以下のいずれかの方法で取得できる
+   - **CLI 経由（AI エージェント向け推奨）**：`gh pr checks <PR番号> --repo <owner>/<repo>` の出力から `Storybook Publish` 行の URL を抽出
+   - **GitHub UI 経由（人間向け）**：PR ページの「All checks have passed」セクションで `Storybook Publish` のリンクをクリック
+   - どちらの方法でも、PR 毎に Chromatic が生成した **公開 Storybook のベース URL** が得られる
+     - 例：`https://622b6c5dc31e9e003a111eb5-vwrshrxnjd.chromatic.com/`
+4. 必要に応じて、特定の Story を指す `?path=/story/<story-id>` を末尾に付ける
+   - 例：`https://622b6c5dc31e9e003a111eb5-cprksiyplm.chromatic.com/?path=/story/features-docs-docsmcppage--japanese`
+5. `gh pr edit <PR番号> --body "..."` で取得した URL を該当セクションに貼り付けて更新
+
+スクリーンショットを併載する場合は、デスクトップ / モバイル の両方を別見出し（H2）で載せると親切。
+
+> 注意：`gh pr checks` の出力には `Deploy Storybook to chromatic` という GitHub Actions ジョブ行（`https://github.com/.../actions/runs/...` 形式）も含まれる。これは **Storybook の URL ではなく CI ジョブの URL** なので混同しないこと。PR 説明欄に書くべきは `Storybook Publish` 行の `*.chromatic.com/` 形式の URL。
+
+#### UI 変更がない場合
+
+「**なし**」とだけ書くのではなく、**なぜ該当しないのか** を理由付きで記載する。
+
+例：
+
+- 「README.md のドキュメント変更のみで Component / UI の変更を伴わないため、Storybook 連携は不要」
+- 「`src/scripts/` 配下の開発用スクリプトの追加のみで、レンダリング対象の Component は含まれないため不要」
+- 「依存 package のバージョン更新のみで、UI 表示への影響は無いため不要」
 
 ### `# 変更点概要`（必須）
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ AI向けのドキュメントを参照してください。
       "env": {}
     },
     "next-devtools": {
+      "type": "stdio",
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]
     },

--- a/README.md
+++ b/README.md
@@ -220,6 +220,78 @@ AI向けのドキュメントを参照してください。
 | `next-devtools`   | Next.js のドキュメント調査・構成確認 |
 | `figma-desktop`   | Figma デザインの取り込み             |
 
+以下は `.mcp.json` をプロジェクトルートに設定する例です。
+
+※ `uvx` の利用には `uv` のインストールが必要です。 `brew install uv` などでインストールしてください。
+
+※ `serena` の `--project` には **このリポジトリをクローンした先の絶対パス** を指定する必要があります。下記サンプル中の `/path/to/lgtm-cat-frontend` の部分はご自身の環境に合わせて書き換えてください（例: `/Users/yourname/gitrepos/lgtm-cat-frontend`）。
+
+```json
+{
+  "mcpServers": {
+    "serena": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "claude-code",
+        "--project",
+        "/path/to/lgtm-cat-frontend"
+      ],
+      "env": {}
+    },
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"],
+      "env": {}
+    },
+    "next-devtools": {
+      "command": "npx",
+      "args": ["-y", "next-devtools-mcp@latest"]
+    },
+    "figma-desktop": {
+      "type": "http",
+      "url": "http://127.0.0.1:3845/mcp"
+    }
+  }
+}
+```
+
 ### 推奨ユーザーグローバル Skill
 
-ブラウザ操作を伴う品質確認を AI エージェントに任せたい場合、[`agent-browser`](https://github.com/vercel-labs/agent-browser/tree/main) のインストールを推奨します。`~/.claude/skills/agent-browser` に配置することで、Claude Code から自動的に利用可能になります。
+ブラウザ操作を伴う品質確認を AI エージェントに任せたい場合、[`agent-browser`](https://github.com/vercel-labs/agent-browser) のインストールを推奨します。
+
+[skills.sh](https://skills.sh/) 提供の `npx skills` CLI が、利用中の AI エージェントを自動検出し、それぞれの公式パスへ Skill を配置してくれます。
+
+```bash
+npx skills add vercel-labs/agent-browser
+```
+
+各 AI エージェントの配置パスは以下のとおりです（自動検出されたエージェントすべてに配置されます）。
+
+| AI エージェント | 配置パス                          |
+| --------------- | --------------------------------- |
+| Claude Code     | `~/.claude/skills/agent-browser/` |
+| Codex CLI       | `~/.codex/skills/agent-browser/`  |
+
+特定のエージェントのみに限定したい場合は `-a` オプションを利用してください。
+
+```bash
+# Codex CLI のみに配置する例
+npx skills add vercel-labs/agent-browser -a codex
+```
+
+#### Codex CLI 利用時の補足
+
+Codex CLI では、バージョンによって Skill 機能の有効化フラグが必要な場合があります。
+
+```bash
+codex --enable skills
+```
+
+詳細は [Codex 公式の Agent Skills ドキュメント](https://developers.openai.com/codex/skills) を参照してください。


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/451

PR #475 の補足対応として、README.md と `create-pr` Skill の AI 開発体験を改善する。

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲

### README.md の改善

- `.mcp.json` のサンプルブロックを README.md に追加（プロジェクトルートに配置する例として）
  - `serena` の `--project` 引数を `/path/to/lgtm-cat-frontend` のプレースホルダー化(個人環境の絶対パスを除去)
  - `uvx` のインストール案内を補足
- `agent-browser` のインストール手順を Codex CLI 対応に拡張
  - `npx skills add vercel-labs/agent-browser` による複数エージェント自動配置の手順を追記
  - Claude Code / Codex CLI 双方の配置先パス対応表を追加
  - `-a` オプションでエージェント限定インストールする例を追加
  - Codex CLI で `codex --enable skills` フラグが必要となる場合があることを補足

### `create-pr` Skill の改善

- `.github/PULL_REQUEST_TEMPLATE.md` の **全セクション必須化**ルールを明文化
  - 内容が無いセクションも省略禁止。`〇〇のため記載なし` のように **理由付きで明示的に記載する** ルールを追加
- `# Storybook の URL、 スクリーンショット` セクションの埋め方を具体化
  - PR 作成 → Chromatic ビルド完了待ち → URL 取得 → `gh pr edit` で説明欄更新、という運用フローを記載
  - URL 取得方法を 2 通り記載（CLI: `gh pr checks`、GitHub UI: `Storybook Publish` リンクをクリック）
  - `Storybook Publish`（Chromatic URL）と `Deploy Storybook to chromatic`（GitHub Actions ジョブ URL）の混同注意も明記

## 対応しない範囲

- AGENTS.md / CLAUDE.md / `.agents/skills/` 配下の他 Skill 定義の変更（PR #475 で対応済み）
- README.md のその他のセクション（環境変数・Node.js セットアップ・デプロイ手順など）

# Storybook の URL、 スクリーンショット

README.md と `.agents/skills/create-pr/SKILL.md`（およびその同期先 `.claude/skills/create-pr/SKILL.md`）のドキュメント変更のみで、Component / UI の変更は含まれないため Storybook 連携は不要。スクリーンショット添付も該当なし。

# 変更点概要

## なぜこの変更が必要か

PR #475 で AI エージェント開発環境を整備したが、以下の運用課題が残っていた。

1. **`.mcp.json` のセットアップ方法が読み手に伝わりにくい**
   - `.mcp.json` は機密情報を含み得るため `.gitignore` で除外されており、リポジトリには含まれない
   - 利用推奨 MCP の表だけでは、各 MCP サーバーをどう設定するかが分からない
   - `serena` のように引数が複雑な MCP は実例を示さないと設定が困難

2. **README に当初書かれていた MCP サンプルに個人環境依存の絶対パスが残っていた**
   - `/Users/keita/gitrepos/lgtm-cat-frontend` のような特定環境の絶対パスがそのまま記載されていた
   - 他開発者がコピペした際に動作しないため、汎用的な表記に置き換える必要があった

3. **`agent-browser` の手順が Claude Code 限定の説明になっていた**
   - 本リポジトリは Codex CLI による開発も前提としているが、`agent-browser` の配置手順が Claude Code 用のみだった
   - `agent-browser` 自体は `npx skills` CLI 経由で複数の AI エージェントへ自動配置する仕組みがあり、Codex CLI も `~/.codex/skills/` で公式に対応している

4. **`create-pr` Skill が PR テンプレートの省略を許容してしまっていた**
   - 当該 Skill の運用中に「`# Storybook の URL、 スクリーンショット` セクションを完全に省略してしまう」という事象が発生した
   - 任意セクションでも空のまま省略すると、レビュアーが「書き忘れ」か「該当なし」か判別できない
   - 「該当なし」を理由付きで明示するルールが Skill 側に欠けていた

5. **`create-pr` Skill に Storybook URL の具体的な取得手順がなかった**
   - 「Chromatic の Storybook URL（PR ごとに自動生成される）」という記述だけでは、AI エージェントがどう取得するか分からなかった

## なぜ `.mcp.json` のサンプルを README にインラインで掲載するか

`.mcp.json` はトークン等の機密情報を含み得るため `.gitignore` で除外されており、リポジトリに実体ファイルを含められない（含めてはいけない）。よって新規開発者が MCP セットアップを行うためには **README 等のドキュメントに設定例を記載する以外の選択肢がない**。リポジトリ内のサンプルファイル（例：`.mcp.json.example`）を別途用意するアプローチもあり得るが、本 PR では新規ファイル追加を避け、既存の README に追記する形を採った。

## なぜ `serena` の `--project` を `/path/to/lgtm-cat-frontend` というプレースホルダー表記にしたか

`serena` の `--project` は MCP サーバー起動時の絶対パスを要求する仕様であり、相対パスや環境変数展開（`$(pwd)` 等）は使えない（`.mcp.json` は静的 JSON のため）。よってサンプルとしては「コピペ後に必ず書き換える前提のプレースホルダー」とするのが筋であり、OSS で広く慣用されている `/path/to/<project名>` 形式を採用した。注釈として「ご自身の環境に合わせて書き換えてください」と書き換え必要性を明示している。

## なぜ `agent-browser` を `npx skills` CLI 経由のインストールに切り替えたか

`agent-browser` は [skills.sh](https://skills.sh/) の `npx skills` CLI が公式の配布チャネルとなっている。この CLI は **利用中の AI エージェントを自動検出して、それぞれの公式パスへ Skill を配置する** 仕組みになっており、ユーザーが Claude Code・Codex CLI それぞれに対して個別にインストール手順を実行する必要がない。この仕組みを README で示すことで、両方のエージェントを使うユーザーが 1 コマンドで導入できるようになる。特定エージェントのみへの配置を希望するケースに備えて `-a` オプションも併記している。

## なぜ `create-pr` Skill にテンプレート省略禁止ルールを追加するか

PR テンプレートの任意セクションを完全に省略してしまうと、レビュアー / 未来の開発者から見て「書き忘れ」か「該当なし」か判別できない。空セクションでも `〇〇のため記載なし` と理由付きで記載すれば、判断の根拠が PR 履歴に残り、後から PR を辿る際の文脈把握がしやすくなる。これは `create-pr` Skill 冒頭の「PR を書く目的」（**未来の開発者・レビュアー視点で文脈を辿れる状態を保つ**）と整合する原則である。

## なぜ Storybook URL 取得手順を Skill に詳述するか

`gh pr checks` の出力には `Storybook Publish`（Chromatic の Storybook URL）と `Deploy Storybook to chromatic`（GitHub Actions ジョブ URL）の 2 種類が含まれ、混同しやすい。AI エージェントが正しい URL を選択できるよう、両者の違いと取得手順を明文化した。GitHub UI 経由（`Storybook Publish` リンクのクリック）と CLI 経由（`gh pr checks`）の 2 通りを記載することで、運用シーンに応じて使い分けられる。

## 主な変更内容

1. **`.mcp.json` の具体例を README に追記** (`README.md`)
   - 「以下は `.mcp.json` をプロジェクトルートに設定する例です。」セクションとして追加
   - `serena` / `chrome-devtools` / `next-devtools` / `figma-desktop` の 4 サーバーすべての設定例
   - `serena` の `--project` は `/path/to/lgtm-cat-frontend` プレースホルダー
   - `uvx` のインストール案内（`brew install uv` 等）

2. **`agent-browser` のインストール手順を Codex 対応に拡張** (`README.md`)
   - `npx skills add vercel-labs/agent-browser` による自動配置の説明
   - Claude Code（`~/.claude/skills/agent-browser/`）と Codex CLI（`~/.codex/skills/agent-browser/`）の配置先対応表
   - `-a codex` などエージェント限定インストールの例
   - Codex CLI における `codex --enable skills` フラグの補足

3. **`create-pr` Skill にテンプレート省略禁止ルールを追加** (`.agents/skills/create-pr/SKILL.md`)
   - 「PR 説明欄のテンプレート構造と各セクションに書くべき内容」直下に「全セクション必須の原則」サブセクションを新設
   - 任意セクションでも空のまま省略禁止、`〇〇のため記載なし` と理由付きで記載するルールを明文化

4. **`create-pr` Skill の Storybook URL セクションを具体化** (`.agents/skills/create-pr/SKILL.md`)
   - `# Storybook の URL、 スクリーンショット` セクションを「必須・該当なしの場合も理由付きで記載」に格上げ
   - UI 変更がある場合の取得手順（PR 作成 → Chromatic ビルド完了待ち → URL 取得 → `gh pr edit`）
   - URL 取得方法 2 通り（`gh pr checks` / GitHub UI の `Storybook Publish` リンク）
   - `Deploy Storybook to chromatic`（CI ジョブ URL）との混同注意
   - UI 変更がない場合の理由付き記載例

5. **Skill の同期** (`.claude/skills/create-pr/SKILL.md`)
   - `npm run sync:agents-skills` により `.claude/skills/` 側にも同内容を反映

# レビュアーに重点的にチェックして欲しい点

- README にインラインで `.mcp.json` 設定例を掲載するアプローチの妥当性。`.mcp.json` 本体は `.gitignore` 対象のためリポジトリに含められず、選択肢として存在するのは「README 等のドキュメントに記載」「別途 `.mcp.json.example` のようなサンプルファイルを追加してリポジトリに含める」の 2 通り。今回は前者を採ったが、後者のほうが扱いやすいか議論したい
- `serena` の `--project` を `/path/to/lgtm-cat-frontend` 表記とした粒度。`<your-clone-path>` のような日本語混じりの記法と比べて、OSS 慣用の `/path/to/...` 形式が本リポジトリの README スタイルとして妥当か
- `agent-browser` の Codex CLI への配置パス（`~/.codex/skills/agent-browser/`）の根拠。OpenAI 公式の `$CODEX_HOME/skills`（デフォルト `~/.codex/skills`）に基づくが、別観点で確認すべき情報があれば
- `create-pr` Skill に書いた「全セクション必須」の原則の粒度。AI エージェントが空セクションを「省略してよい」と誤読しないために強い表現を採ったが、運用上きつすぎる場合は緩和の余地があるか
- Storybook URL 取得手順について、CLI（`gh pr checks`）と GitHub UI の両方を Skill に記載した判断。AI エージェント向けには CLI 経由のみで十分、人間向けの説明は不要、という方針もあり得る

# 補足情報

- 関連 PR：#475（AI 向けルールから効果のないルールを削除し用途固有ルールを Skill 化）
- 参考資料：
  - [Codex Agent Skills 公式ドキュメント](https://developers.openai.com/codex/skills)
  - [skills.sh — Open Agent Skills Directory](https://skills.sh/)
  - [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)