### PR TITLE
MIT ライセンスを追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 nekochans
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lgtm-cat-frontend",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev -p 2222",
     "build": "next build",


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/lgtm-cat-frontend/issues/493

# この PR で対応する範囲 / この PR で対応しない範囲

## 対応する範囲

- リポジトリルートへの MIT `LICENSE` の追加
- `package.json` への `"license": "MIT"` の追加

## 対応しない範囲

- `lgtm-cat` / `lgtm-cat-cli` / `lgtm-cat-terraform` 等、同じく LICENSE が未設定の兄弟リポジトリへの対応。本 PR は当リポジトリのみを対象とする

# Storybook の URL、 スクリーンショット

`LICENSE` の追加と `package.json` へのフィールド追加のみで、Component / UI の変更を伴わないため Storybook 連携は不要。

# 変更点概要

## なぜこの変更が必要か

本リポジトリは公開されているにも関わらず `LICENSE` ファイルが存在せず、GitHub API の `GET /repos/nekochans/lgtm-cat-frontend/license` が 404 を返す状態だった。

ライセンスが明示されていないソースコードは、公開されていても著作権法上は全ての権利が留保された状態であり、第三者は複製・改変・再配布を行えない。OSI の Open Source Definition も満たさない。ソースコードを公開している以上、第三者が安心して利用・参照できる状態にしておくべきなので、ライセンスを明示する。

## 主な変更内容

1. **MIT ライセンスの追加** (`LICENSE`)
   - nekochans organization の既存リポジトリ（`convert-to-webp` 等）の `LICENSE` と diff で完全一致する内容

2. **ライセンス表記の追加** (`package.json`)
   - `"license": "MIT"` を追加

## なぜ MIT としたか

nekochans organization の公開リポジトリは約 25 リポジトリが MIT で統一されており、ライセンスが未設定なのは `lgtm-cat-*` 系のみ。新たにライセンスを選定するのではなく、既存の慣例に合わせるのが一貫性の面で妥当と判断した。

## なぜ著作権表記の年を 2021 としたか

GitHub 上のリポジトリ作成日（2021-02-15）および初回コミットの年に合わせた。organization の他リポジトリも同様にリポジトリ作成年を記載する運用になっている。

## なぜ `"private": true` のまま `"license"` を追加したか

`package.json` の `"private": true` は npm レジストリへの誤公開を防ぐフラグであり、ライセンス表記とは独立した設定。npm への公開予定は無いが、`"license"` フィールドがあることで各種ツールがライセンスを機械的に判別できるため追加した。

# レビュアーに重点的にチェックして欲しい点

- 著作権表記を個人名ではなく `nekochans`（organization 名）としている点。本リポジトリには複数のコントリビューターが存在するため、権利者の記載として organization 名を用いる方針が妥当か議論したい
- 兄弟リポジトリ（`lgtm-cat` 等）を本 PR のスコープ外とした判断。ライセンスは一括で揃えるべきか、リポジトリ単位で分けるべきかについて意見が欲しい

# 補足情報

GitHub のライセンス判定 API は `ref` パラメータで本ブランチを指定しても 404 を返す。ライセンス判定はデフォルトブランチに対して行われるとみられるため、GitHub 上で MIT として認識されることの確認はマージ後に行う。ブランチ上に `LICENSE` が正しい内容で存在すること自体は Contents API で確認済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * MITライセンスを追加しました。
  * 著作権表示、利用・再配布条件、無保証および責任制限を明記しました。
  * パッケージのライセンス情報をMITとして表示するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->